### PR TITLE
Add PHPUnit coverage for module manager and CLI smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# Amplisio AIO for WooCommerce
+
+Amplisio AIO is a modular, production-ready toolkit for WooCommerce merchants. It provides actionable intelligence, lifecycle automation, and growth tools built on modern WordPress architecture with full HPOS compatibility.
+
+## Requirements
+
+- PHP 8.1 or higher
+- WordPress 6.3 or higher
+- WooCommerce 8.0 or higher (HPOS enabled or legacy)
+
+## Installation
+
+1. Clone or download this repository into your WordPress `wp-content/plugins` directory.
+2. Install PHP dependencies:
+
+   ```bash
+   composer install
+   ```
+
+3. (Optional) Install Node dependencies for asset builds:
+
+   ```bash
+   npm install
+   ```
+
+4. Activate **Amplisio AIO for WooCommerce** from the WordPress Plugins screen.
+
+On activation, the plugin seeds default settings and declares HPOS compatibility via `Automattic\WooCommerce\Utilities\FeaturesUtil`.
+
+## Building assets
+
+The dashboard UI is compiled with [esbuild](https://esbuild.github.io/). Run:
+
+```bash
+npm run build
+```
+
+This bundles `assets/js/admin/dashboard.js` and outputs to `build/admin-dashboard.js`. Use `npm run watch` during development for incremental builds.
+
+## HPOS notes
+
+- The plugin declares compatibility with the HPOS custom order tables feature and avoids deprecated CRUD methods when working with orders and coupons.
+- The Abandoned Cart module relies on HPOS-aware APIs (such as `Automattic\WooCommerce\Utilities\OrderUtil` and `WC_Order` data objects) to associate carts with orders, and safely falls back to email matching when HPOS is disabled.
+- Custom tables (`amplisio_carts`, `amplisio_recovered_carts`, `amplisio_back_in_stock`) are provisioned with indexed columns for performant lookups and cleanup jobs.
+
+## Modules
+
+Each module registers through the service container and module manager. Modules are disabled by default unless specified. Administrators can toggle modules from **Amplisio → Dashboard**.
+
+| Module | Description |
+| ------ | ----------- |
+| `analytics` | Aggregates store performance metrics, exposes REST data, and populates dashboard cards. |
+| `abandoned_cart` | Captures open carts (guest and customer), automates multi-step recovery sequences with optional coupons, and surfaces REST stats with GDPR tooling. |
+| `recovered_carts` | Tracks recovered checkout sessions, stores summaries in an indexed table, and surfaces KPIs. |
+| `back_in_stock` | Collects back-in-stock signups and provides REST endpoints for public opt-ins and admin metrics. |
+
+## Dashboard & settings
+
+The Amplisio dashboard is a single-page experience that exposes:
+
+- KPI cards (AOV, conversion rate, customer lifetime value, recovered carts, recovered revenue, back-in-stock signups)
+- Theme settings (font family, primary & accent colors, border radius)
+- Module toggles with accessibility-friendly switch controls
+- Abandoned cart sequence designer with preview and test utilities when the module is enabled
+
+Settings persist via the REST API (`amplisio/v1/settings`) with nonce and capability checks. Modules only bootstrap when enabled.
+
+## Security
+
+- All REST endpoints require capability checks and WP REST nonces.
+- Input is sanitized via helper utilities before persisting.
+- Database access uses `$wpdb->prepare()` or parameterized inserts.
+
+## Performance
+
+- Background maintenance runs via Action Scheduler hook `amplisio_aio_scheduled_run`.
+- Module services perform batched cleanups of custom tables.
+- Metrics are cached in transients to avoid repeated heavy queries.
+
+## Internationalization
+
+Text strings load from `languages/` using the `amplisio-aio` text domain.
+
+## CLI commands
+
+Two WP-CLI commands are registered when WP-CLI is available:
+
+- `wp amplisio status` – List plugin version and module enablement.
+- `wp amplisio module <enable|disable> <module>` – Toggle module state from the command line.
+
+## Development tooling
+
+- Composer autoloads PHP classes via PSR-4.
+- `phpcs.xml` configures WordPress Coding Standards.
+- `phpunit.xml.dist` and `tests/bootstrap.php` provide a PHPUnit skeleton.
+
+## Hooks reference
+
+| Hook | Type | Description |
+| ---- | ---- | ----------- |
+| `amplisio_aio_scheduled_run` | Action Scheduler | Fires daily to let enabled modules perform maintenance. |
+| `amplisio_aio_abandoned_sequence` | Action Scheduler | Dispatched per abandoned cart sequence to deliver recovery emails. |
+| `amplisio_aio_generate_coupon` | Filter | Override the default coupon generator for abandoned cart emails. |
+| `amplisio_aio_abandoned_cart_email_headers` | Filter | Modify headers used for abandoned cart recovery emails and tests. |
+| `woocommerce_order_status_completed` | Action | Intercepted by the Recovered Carts module to log recoveries when the `_amplisio_recovered_cart` flag is set on an order. |
+
+## Support & contributions
+
+Contributions are welcome via pull requests. Please run `composer install` and `npm run build` before submitting changes, and follow the WordPress Coding Standards enforced by PHPCS.

--- a/amplisio-aio.php
+++ b/amplisio-aio.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Plugin Name:       Amplisio AIO for WooCommerce
+ * Plugin URI:        https://example.com/amplisio-aio
+ * Description:       Modular growth suite for WooCommerce with actionable analytics and automation.
+ * Version:           1.0.0
+ * Author:            Amplisio
+ * Author URI:        https://example.com
+ * Requires PHP:      8.1
+ * Requires at least: 6.3
+ * Text Domain:       amplisio-aio
+ * Domain Path:       /languages
+ * License:           GPL-3.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
+ * WC requires at least: 8.0
+ * WC tested up to:   8.5
+ */
+
+define( 'AMPLISIO_AIO_FILE', __FILE__ );
+define( 'AMPLISIO_AIO_PATH', plugin_dir_path( __FILE__ ) );
+define( 'AMPLISIO_AIO_URL', plugin_dir_url( __FILE__ ) );
+define( 'AMPLISIO_AIO_VERSION', '1.0.0' );
+
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Ensure Action Scheduler is available.
+if ( ! class_exists( 'ActionScheduler' ) && file_exists( __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php' ) ) {
+    require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
+}
+
+use Amplisio\AIO\Plugin;
+
+if ( ! function_exists( 'amplisio_aio' ) ) {
+    function amplisio_aio(): Plugin {
+        static $plugin = null;
+
+        if ( null === $plugin ) {
+            $plugin = new Plugin( AMPLISIO_AIO_FILE );
+        }
+
+        return $plugin;
+    }
+}
+
+amplisio_aio()->boot();

--- a/assets/css/admin/dashboard.css
+++ b/assets/css/admin/dashboard.css
@@ -1,0 +1,260 @@
+:root {
+  color-scheme: light dark;
+}
+
+.amplisio-dashboard__layout {
+  display: grid;
+  gap: 2rem;
+  font-family: var(--amplisio-font-family, 'Inter', sans-serif);
+  color: #0f172a;
+}
+
+.amplisio-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.amplisio-card {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.amplisio-card__title {
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.7);
+  margin: 0 0 0.5rem;
+}
+
+.amplisio-card__value {
+  font-size: 1.8rem;
+  margin: 0;
+  font-weight: 600;
+  color: var(--amplisio-primary, #2563eb);
+}
+
+.amplisio-card__description {
+  margin-top: 0.75rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.amplisio-form {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.amplisio-fieldset legend {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.amplisio-field {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.amplisio-field input,
+.amplisio-field textarea,
+.amplisio-field select {
+  border-radius: var(--amplisio-radius, 12px);
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+}
+
+.amplisio-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.amplisio-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.amplisio-toggle input[type='checkbox'] {
+  width: 46px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.1);
+  appearance: none;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.amplisio-toggle input[type='checkbox']::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.amplisio-toggle input[type='checkbox']:checked {
+  background: var(--amplisio-accent, #ec4899);
+}
+
+.amplisio-toggle input[type='checkbox']:checked::after {
+  transform: translateX(22px);
+}
+
+.amplisio-button {
+  justify-self: start;
+  background: var(--amplisio-primary, #2563eb);
+  color: #fff;
+  border: none;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.amplisio-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.amplisio-button--ghost {
+  background: transparent;
+  color: var(--amplisio-primary, #2563eb);
+  border: 1px solid currentColor;
+}
+
+.amplisio-panel {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-panel__form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-panel__notice {
+  color: rgba(15, 23, 42, 0.65);
+  font-style: italic;
+}
+
+.amplisio-panel__message {
+  color: var(--amplisio-primary, #2563eb);
+  font-weight: 500;
+}
+
+.amplisio-sequence {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.amplisio-sequence--settings {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.amplisio-sequence__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.amplisio-sequence__header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.amplisio-sequence__variables {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.85rem;
+}
+
+.amplisio-sequence__coupon {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.amplisio-sequence__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.amplisio-preview {
+  border-top: 1px solid rgba(15, 23, 42, 0.1);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.amplisio-preview__body {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  padding: 1rem;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.amplisio-dashboard__loading,
+.amplisio-dashboard__empty {
+  color: rgba(15, 23, 42, 0.7);
+  font-style: italic;
+}
+
+@media (prefers-color-scheme: dark) {
+  .amplisio-dashboard__layout,
+  .amplisio-card,
+  .amplisio-form,
+  .amplisio-panel {
+    color: #e2e8f0;
+    background: #0f172a;
+    border-color: rgba(226, 232, 240, 0.1);
+  }
+
+  .amplisio-card,
+  .amplisio-form,
+  .amplisio-panel {
+    box-shadow: none;
+  }
+
+  .amplisio-field input,
+  .amplisio-field textarea,
+  .amplisio-field select {
+    background: rgba(226, 232, 240, 0.1);
+    color: #e2e8f0;
+    border-color: rgba(226, 232, 240, 0.2);
+  }
+}

--- a/assets/js/admin/dashboard.js
+++ b/assets/js/admin/dashboard.js
@@ -1,0 +1,705 @@
+const {
+  root: apiRoot,
+  nonce,
+  modules: initialModules,
+  themeFallbacks = {},
+  themeCssVariables: baseThemeVariables = {},
+} = window.amplisioAioData || {};
+const root = document.getElementById('amplisio-aio-dashboard');
+
+if (root && apiRoot) {
+  const initialAbandoned = {
+    settings: null,
+    loading: false,
+    saving: false,
+    preview: null,
+    message: '',
+    testEmail: '',
+    sendingTest: false,
+  };
+
+  const state = {
+    cards: [],
+    theme: window.amplisioAioData.settings.theme || {},
+    modules: initialModules,
+    loading: false,
+    saving: false,
+    abandoned: { ...initialAbandoned },
+  };
+
+  const translate = (text) => {
+    if (window.wp && window.wp.i18n && typeof window.wp.i18n.__ === 'function') {
+      return window.wp.i18n.__(text, 'amplisio-aio');
+    }
+
+    return text;
+  };
+
+  const fetchJSON = async (path, options = {}) => {
+    const response = await fetch(`${apiRoot}/${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': nonce,
+        ...(options.headers || {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+
+    return response.json();
+  };
+
+  const withAbandoned = (partial) => ({
+    abandoned: {
+      ...state.abandoned,
+      ...partial,
+    },
+  });
+
+  const setState = (partial) => {
+    Object.assign(state, partial);
+    render();
+  };
+
+  const resolveThemeVariable = (key, override) => {
+    const value = typeof override === 'string' ? override.trim() : '';
+    if (value) {
+      return value;
+    }
+
+    return baseThemeVariables[key] || '';
+  };
+
+  const applyThemeVariables = (node) => {
+    const variables = {
+      '--amplisio-font-family': resolveThemeVariable('--amplisio-font-family', state.theme.fontFamily),
+      '--amplisio-primary': resolveThemeVariable('--amplisio-primary', state.theme.primaryColor),
+      '--amplisio-accent': resolveThemeVariable('--amplisio-accent', state.theme.accentColor),
+      '--amplisio-radius': resolveThemeVariable('--amplisio-radius', state.theme.radius),
+    };
+
+    Object.entries(variables).forEach(([name, value]) => {
+      if (value) {
+        node.style.setProperty(name, value);
+      } else {
+        node.style.removeProperty(name);
+      }
+    });
+  };
+
+  const isAbandonedEnabled = () =>
+    state.modules.some((module) => module.id === 'abandoned_cart' && module.enabled);
+
+  const loadDashboard = async () => {
+    try {
+      setState({ loading: true });
+      const data = await fetchJSON('dashboard');
+      setState({ cards: data.cards || [], theme: data.theme || state.theme, loading: false });
+      if (isAbandonedEnabled()) {
+        await loadAbandonedSettings();
+      } else {
+        setState(withAbandoned({ ...initialAbandoned }));
+      }
+    } catch (error) {
+      console.error(error);
+      setState({ loading: false });
+    }
+  };
+
+  const loadAbandonedSettings = async () => {
+    if (!isAbandonedEnabled()) {
+      setState(withAbandoned({ ...initialAbandoned }));
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ loading: true, message: '', preview: null }));
+      const settings = await fetchJSON('abandoned-cart/sequences');
+      setState(withAbandoned({ settings, loading: false }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ loading: false, message: translate('Unable to load abandoned cart settings.') }));
+    }
+  };
+
+  const updateSettings = async (event) => {
+    event.preventDefault();
+    const form = event.target;
+    const formData = new FormData(form);
+    const modulesPayload = {};
+
+    state.modules.forEach((module) => {
+      const field = form.querySelector(`[data-module-id="${module.id}"]`);
+      modulesPayload[module.id] = field ? field.checked : module.enabled;
+    });
+
+    const payload = {
+      theme: {
+        fontFamily: (formData.get('fontFamily') || '').trim(),
+        primaryColor: (formData.get('primaryColor') || '').trim(),
+        accentColor: (formData.get('accentColor') || '').trim(),
+        radius: (formData.get('radius') || '').trim(),
+      },
+      modules: modulesPayload,
+    };
+
+    try {
+      setState({ saving: true });
+      const updated = await fetchJSON('settings', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const modules = state.modules.map((module) => ({
+        ...module,
+        enabled: Boolean(modulesPayload[module.id]),
+      }));
+      setState({
+        theme: updated.theme,
+        modules,
+        saving: false,
+      });
+      if (!modulesPayload.abandoned_cart) {
+        setState(withAbandoned({ ...initialAbandoned }));
+      }
+      await loadDashboard();
+    } catch (error) {
+      console.error(error);
+      setState({ saving: false });
+    }
+  };
+
+  const updateSequenceField = (sequenceId, field, value) => {
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    const settings = {
+      ...state.abandoned.settings,
+      sequences: state.abandoned.settings.sequences.map((sequence) =>
+        sequence.id === sequenceId
+          ? {
+              ...sequence,
+              [field]: value,
+            }
+          : sequence
+      ),
+    };
+
+    setState(withAbandoned({ settings }));
+  };
+
+  const updateTimingField = (field, value) => {
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    const settings = {
+      ...state.abandoned.settings,
+      [field]: value,
+    };
+
+    setState(withAbandoned({ settings }));
+  };
+
+  const saveSequences = async (event) => {
+    event.preventDefault();
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ saving: true, message: '' }));
+      const updated = await fetchJSON('abandoned-cart/sequences', {
+        method: 'POST',
+        body: JSON.stringify(state.abandoned.settings),
+      });
+      setState(withAbandoned({ settings: updated, saving: false, message: translate('Sequences saved.') }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ saving: false, message: translate('Unable to save sequences.') }));
+    }
+  };
+
+  const previewSequence = async (sequenceId) => {
+    try {
+      setState(withAbandoned({ message: '', preview: { loading: true } }));
+      const preview = await fetchJSON('abandoned-cart/preview', {
+        method: 'POST',
+        body: JSON.stringify({ sequenceId }),
+      });
+      setState(withAbandoned({ preview, message: '' }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ preview: null, message: translate('Unable to generate preview.') }));
+    }
+  };
+
+  const sendTest = async (sequenceId) => {
+    if (!state.abandoned.testEmail) {
+      setState(withAbandoned({ message: translate('Enter a test email before sending.'), preview: state.abandoned.preview }));
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ sendingTest: true, message: '' }));
+      await fetchJSON('abandoned-cart/test', {
+        method: 'POST',
+        body: JSON.stringify({ sequenceId, email: state.abandoned.testEmail }),
+      });
+      setState(withAbandoned({ sendingTest: false, message: translate('Test email sent.') }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ sendingTest: false, message: translate('Unable to send test email.') }));
+    }
+  };
+
+  const createCard = (card) => {
+    const article = document.createElement('article');
+    article.className = 'amplisio-card';
+    article.setAttribute('role', 'group');
+    article.setAttribute('aria-label', card.title);
+
+    const title = document.createElement('h3');
+    title.textContent = card.title;
+    title.className = 'amplisio-card__title';
+    article.appendChild(title);
+
+    const value = document.createElement('p');
+    value.className = 'amplisio-card__value';
+    value.textContent = card.value;
+    article.appendChild(value);
+
+    const description = document.createElement('p');
+    description.className = 'amplisio-card__description';
+    description.textContent = card.description;
+    article.appendChild(description);
+
+    return article;
+  };
+
+  const renderCards = () => {
+    const section = document.createElement('section');
+    section.className = 'amplisio-grid';
+    section.setAttribute('aria-live', 'polite');
+
+    if (state.loading) {
+      const loader = document.createElement('p');
+      loader.textContent = translate('Loading metrics…');
+      loader.className = 'amplisio-dashboard__loading';
+      section.appendChild(loader);
+      return section;
+    }
+
+    if (!state.cards.length) {
+      const empty = document.createElement('p');
+      empty.textContent = translate('No data available yet.');
+      empty.className = 'amplisio-dashboard__empty';
+      section.appendChild(empty);
+      return section;
+    }
+
+    state.cards.forEach((card) => {
+      section.appendChild(createCard(card));
+    });
+
+    return section;
+  };
+
+  const renderThemeForm = () => {
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'amplisio-fieldset';
+
+    const legend = document.createElement('legend');
+    legend.textContent = translate('Theme');
+    fieldset.appendChild(legend);
+
+    const fields = [
+      {
+        label: translate('Font family'),
+        name: 'fontFamily',
+        type: 'text',
+        value: state.theme.fontFamily || '',
+        placeholder: themeFallbacks.fontFamily || '"Inter", sans-serif',
+      },
+      {
+        label: translate('Primary color'),
+        name: 'primaryColor',
+        type: 'text',
+        value: state.theme.primaryColor || '',
+        placeholder: themeFallbacks.primaryColor || '#2563eb',
+      },
+      {
+        label: translate('Accent color'),
+        name: 'accentColor',
+        type: 'text',
+        value: state.theme.accentColor || '',
+        placeholder: themeFallbacks.accentColor || '#ec4899',
+      },
+      {
+        label: translate('Border radius'),
+        name: 'radius',
+        type: 'text',
+        value: state.theme.radius || '',
+        placeholder: themeFallbacks.radius || '12px',
+      },
+    ];
+
+    fields.forEach((field) => {
+      const wrapper = document.createElement('label');
+      wrapper.className = 'amplisio-field';
+      wrapper.textContent = field.label;
+      const input = document.createElement('input');
+      input.name = field.name;
+      input.type = field.type;
+      input.value = field.value || '';
+      if (field.placeholder) {
+        input.placeholder = field.placeholder;
+      }
+      input.autocomplete = 'off';
+      input.spellcheck = false;
+      input.setAttribute('aria-label', field.label);
+      wrapper.appendChild(input);
+      fieldset.appendChild(wrapper);
+    });
+
+    return fieldset;
+  };
+
+  const renderModuleToggles = () => {
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'amplisio-fieldset';
+
+    const legend = document.createElement('legend');
+    legend.textContent = translate('Modules');
+    fieldset.appendChild(legend);
+
+    state.modules.forEach((module) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'amplisio-toggle';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.id = `module-${module.id}`;
+      input.checked = module.enabled;
+      input.dataset.moduleId = module.id;
+      input.setAttribute('role', 'switch');
+      input.setAttribute('aria-checked', String(module.enabled));
+      input.addEventListener('change', () => {
+        input.setAttribute('aria-checked', String(input.checked));
+      });
+
+      const label = document.createElement('label');
+      label.setAttribute('for', input.id);
+      label.textContent = module.name;
+
+      wrapper.appendChild(input);
+      wrapper.appendChild(label);
+      fieldset.appendChild(wrapper);
+    });
+
+    return fieldset;
+  };
+
+  const createSequenceField = (sequence, label, name, config = {}) => {
+    const { type = 'text', options = [] } = config;
+    const field = document.createElement('label');
+    field.className = 'amplisio-field amplisio-field--stacked';
+    field.textContent = label;
+
+    let input;
+    if ('textarea' === type) {
+      input = document.createElement('textarea');
+    } else if ('select' === type) {
+      input = document.createElement('select');
+      options.forEach((option) => {
+        const opt = document.createElement('option');
+        opt.value = option;
+        opt.textContent = option;
+        if (sequence[name] === option) {
+          opt.selected = true;
+        }
+        input.appendChild(opt);
+      });
+    } else {
+      input = document.createElement('input');
+      input.type = type;
+    }
+
+    if ('checkbox' === type) {
+      input.checked = Boolean(sequence[name]);
+      input.addEventListener('change', (event) => {
+        updateSequenceField(sequence.id, name, event.target.checked);
+      });
+    } else if ('number' === type) {
+      input.value = sequence[name] ?? 0;
+      input.addEventListener('input', (event) => {
+        const numeric = event.target.valueAsNumber;
+        const value = Number.isNaN(numeric) ? 0 : Math.max(0, numeric);
+        updateSequenceField(sequence.id, name, value);
+      });
+    } else if ('select' === type) {
+      input.addEventListener('change', (event) => {
+        updateSequenceField(sequence.id, name, event.target.value);
+      });
+    } else {
+      input.value = sequence[name] ?? '';
+      input.addEventListener('input', (event) => {
+        updateSequenceField(sequence.id, name, event.target.value);
+      });
+    }
+
+    input.setAttribute('aria-label', label);
+    input.dataset.sequenceField = `${sequence.id}-${name}`;
+
+    field.appendChild(input);
+    return field;
+  };
+
+  const renderSequence = (sequence) => {
+    const container = document.createElement('article');
+    container.className = 'amplisio-sequence';
+
+    const header = document.createElement('header');
+    header.className = 'amplisio-sequence__header';
+    const title = document.createElement('h4');
+    title.textContent = sequence.name || sequence.id;
+    header.appendChild(title);
+    container.appendChild(header);
+
+    container.appendChild(createSequenceField(sequence, translate('Delay (minutes)'), 'delay', { type: 'number' }));
+    container.appendChild(createSequenceField(sequence, translate('Email subject'), 'subject'));
+
+    const bodyField = createSequenceField(sequence, translate('Email body'), 'body', { type: 'textarea' });
+    container.appendChild(bodyField);
+
+    const variables = document.createElement('p');
+    variables.className = 'amplisio-sequence__variables';
+    variables.textContent = translate('Available variables: {{first_name}}, {{cart_link}}, {{coupon}}');
+    container.appendChild(variables);
+
+    const couponWrapper = document.createElement('div');
+    couponWrapper.className = 'amplisio-sequence__coupon';
+
+    const couponToggle = createSequenceField(sequence, translate('Generate coupon automatically'), 'autoCoupon', { type: 'checkbox' });
+    couponWrapper.appendChild(couponToggle);
+
+    couponWrapper.appendChild(
+      createSequenceField(sequence, translate('Coupon type'), 'couponType', {
+        type: 'select',
+        options: ['percent', 'fixed_cart', 'fixed_product'],
+      })
+    );
+    couponWrapper.appendChild(createSequenceField(sequence, translate('Coupon amount'), 'couponAmount', { type: 'number' }));
+    couponWrapper.appendChild(
+      createSequenceField(sequence, translate('Coupon expiry (days)'), 'couponExpiryDays', { type: 'number' })
+    );
+
+    container.appendChild(couponWrapper);
+
+    const actions = document.createElement('div');
+    actions.className = 'amplisio-sequence__actions';
+
+    const previewButton = document.createElement('button');
+    previewButton.type = 'button';
+    previewButton.className = 'amplisio-button amplisio-button--ghost';
+    previewButton.textContent = translate('Preview');
+    previewButton.addEventListener('click', () => previewSequence(sequence.id));
+    actions.appendChild(previewButton);
+
+    const testButton = document.createElement('button');
+    testButton.type = 'button';
+    testButton.className = 'amplisio-button amplisio-button--ghost';
+    testButton.textContent = state.abandoned.sendingTest
+      ? translate('Sending…')
+      : translate('Send test');
+    testButton.disabled = state.abandoned.sendingTest;
+    testButton.addEventListener('click', () => sendTest(sequence.id));
+    actions.appendChild(testButton);
+
+    container.appendChild(actions);
+
+    return container;
+  };
+
+  const renderTimingControls = () => {
+    if (!state.abandoned.settings) {
+      return document.createDocumentFragment();
+    }
+
+    const container = document.createElement('article');
+    container.className = 'amplisio-sequence amplisio-sequence--settings';
+
+    const heading = document.createElement('h4');
+    heading.textContent = translate('Sequence timing');
+    container.appendChild(heading);
+
+    const abandonField = document.createElement('label');
+    abandonField.className = 'amplisio-field amplisio-field--stacked';
+    abandonField.textContent = translate('Mark abandoned after (minutes)');
+    const abandonInput = document.createElement('input');
+    abandonInput.type = 'number';
+    abandonInput.min = '5';
+    abandonInput.value = state.abandoned.settings.abandonAfterMinutes;
+    abandonInput.addEventListener('input', (event) => {
+      const numeric = event.target.valueAsNumber;
+      const value = Number.isNaN(numeric) ? state.abandoned.settings.abandonAfterMinutes : Math.max(5, numeric);
+      updateTimingField('abandonAfterMinutes', value);
+    });
+    abandonField.appendChild(abandonInput);
+    container.appendChild(abandonField);
+
+    const expireField = document.createElement('label');
+    expireField.className = 'amplisio-field amplisio-field--stacked';
+    expireField.textContent = translate('Expire abandoned carts after (days)');
+    const expireInput = document.createElement('input');
+    expireInput.type = 'number';
+    expireInput.min = '1';
+    expireInput.value = state.abandoned.settings.expireAfterDays;
+    expireInput.addEventListener('input', (event) => {
+      const numeric = event.target.valueAsNumber;
+      const value = Number.isNaN(numeric) ? state.abandoned.settings.expireAfterDays : Math.max(1, numeric);
+      updateTimingField('expireAfterDays', value);
+    });
+    expireField.appendChild(expireInput);
+    container.appendChild(expireField);
+
+    return container;
+  };
+
+  const renderAbandonedSequences = () => {
+    const panel = document.createElement('section');
+    panel.className = 'amplisio-panel';
+
+    const heading = document.createElement('h3');
+    heading.textContent = translate('Abandoned cart sequences');
+    panel.appendChild(heading);
+
+    if (!isAbandonedEnabled()) {
+      const disabled = document.createElement('p');
+      disabled.textContent = translate('Enable the abandoned cart module to manage recovery emails.');
+      disabled.className = 'amplisio-panel__notice';
+      panel.appendChild(disabled);
+      return panel;
+    }
+
+    if (state.abandoned.loading) {
+      const loading = document.createElement('p');
+      loading.textContent = translate('Loading sequences…');
+      loading.className = 'amplisio-panel__notice';
+      panel.appendChild(loading);
+      return panel;
+    }
+
+    if (!state.abandoned.settings) {
+      const empty = document.createElement('p');
+      empty.textContent = translate('No sequences configured yet.');
+      empty.className = 'amplisio-panel__notice';
+      panel.appendChild(empty);
+      return panel;
+    }
+
+    const form = document.createElement('form');
+    form.className = 'amplisio-panel__form';
+    form.addEventListener('submit', saveSequences);
+
+    form.appendChild(renderTimingControls());
+
+    state.abandoned.settings.sequences.forEach((sequence) => {
+      form.appendChild(renderSequence(sequence));
+    });
+
+    const testField = document.createElement('label');
+    testField.className = 'amplisio-field amplisio-field--stacked';
+    testField.textContent = translate('Test email address');
+    const testInput = document.createElement('input');
+    testInput.type = 'email';
+    testInput.value = state.abandoned.testEmail;
+    testInput.placeholder = translate('name@example.com');
+    testInput.setAttribute('aria-label', translate('Test email address'));
+    testInput.addEventListener('input', (event) => {
+      setState(withAbandoned({ testEmail: event.target.value }));
+    });
+    testField.appendChild(testInput);
+    form.appendChild(testField);
+
+    const save = document.createElement('button');
+    save.type = 'submit';
+    save.className = 'amplisio-button';
+    save.textContent = state.abandoned.saving ? translate('Saving…') : translate('Save sequences');
+    save.disabled = state.abandoned.saving;
+    form.appendChild(save);
+
+    if (state.abandoned.message) {
+      const message = document.createElement('p');
+      message.className = 'amplisio-panel__message';
+      message.textContent = state.abandoned.message;
+      form.appendChild(message);
+    }
+
+    if (state.abandoned.preview && state.abandoned.preview.loading) {
+      const loading = document.createElement('p');
+      loading.className = 'amplisio-panel__notice';
+      loading.textContent = translate('Generating preview…');
+      form.appendChild(loading);
+    }
+
+    if (state.abandoned.preview && !state.abandoned.preview.loading) {
+      const preview = document.createElement('section');
+      preview.className = 'amplisio-preview';
+
+      const subject = document.createElement('h4');
+      subject.textContent = `${translate('Subject')}: ${state.abandoned.preview.subject || ''}`;
+      preview.appendChild(subject);
+
+      const body = document.createElement('div');
+      body.className = 'amplisio-preview__body';
+      body.innerHTML = state.abandoned.preview.body || '';
+      preview.appendChild(body);
+
+      form.appendChild(preview);
+    }
+
+    panel.appendChild(form);
+
+    return panel;
+  };
+
+  const render = () => {
+    root.innerHTML = '';
+
+    const layout = document.createElement('div');
+    layout.className = 'amplisio-dashboard__layout';
+    applyThemeVariables(layout);
+
+    const cardsSection = renderCards();
+    layout.appendChild(cardsSection);
+
+    const form = document.createElement('form');
+    form.className = 'amplisio-form';
+    form.addEventListener('submit', updateSettings);
+
+    form.appendChild(renderThemeForm());
+    form.appendChild(renderModuleToggles());
+
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.className = 'amplisio-button';
+    submit.textContent = state.saving ? translate('Saving…') : translate('Save changes');
+    submit.disabled = state.saving;
+    form.appendChild(submit);
+
+    layout.appendChild(form);
+
+    if (isAbandonedEnabled()) {
+      layout.appendChild(renderAbandonedSequences());
+    }
+
+    root.appendChild(layout);
+  };
+
+  render();
+  loadDashboard();
+}

--- a/build/admin-dashboard.css
+++ b/build/admin-dashboard.css
@@ -1,0 +1,260 @@
+:root {
+  color-scheme: light dark;
+}
+
+.amplisio-dashboard__layout {
+  display: grid;
+  gap: 2rem;
+  font-family: var(--amplisio-font-family, 'Inter', sans-serif);
+  color: #0f172a;
+}
+
+.amplisio-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.amplisio-card {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.amplisio-card__title {
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.7);
+  margin: 0 0 0.5rem;
+}
+
+.amplisio-card__value {
+  font-size: 1.8rem;
+  margin: 0;
+  font-weight: 600;
+  color: var(--amplisio-primary, #2563eb);
+}
+
+.amplisio-card__description {
+  margin-top: 0.75rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.amplisio-form {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.amplisio-fieldset legend {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.amplisio-field {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.amplisio-field input,
+.amplisio-field textarea,
+.amplisio-field select {
+  border-radius: var(--amplisio-radius, 12px);
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+}
+
+.amplisio-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.amplisio-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.amplisio-toggle input[type='checkbox'] {
+  width: 46px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.1);
+  appearance: none;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.amplisio-toggle input[type='checkbox']::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.amplisio-toggle input[type='checkbox']:checked {
+  background: var(--amplisio-accent, #ec4899);
+}
+
+.amplisio-toggle input[type='checkbox']:checked::after {
+  transform: translateX(22px);
+}
+
+.amplisio-button {
+  justify-self: start;
+  background: var(--amplisio-primary, #2563eb);
+  color: #fff;
+  border: none;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.amplisio-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.amplisio-button--ghost {
+  background: transparent;
+  color: var(--amplisio-primary, #2563eb);
+  border: 1px solid currentColor;
+}
+
+.amplisio-panel {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-panel__form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.amplisio-panel__notice {
+  color: rgba(15, 23, 42, 0.65);
+  font-style: italic;
+}
+
+.amplisio-panel__message {
+  color: var(--amplisio-primary, #2563eb);
+  font-weight: 500;
+}
+
+.amplisio-sequence {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--amplisio-radius, 12px);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.amplisio-sequence--settings {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.amplisio-sequence__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.amplisio-sequence__header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.amplisio-sequence__variables {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.85rem;
+}
+
+.amplisio-sequence__coupon {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.amplisio-sequence__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.amplisio-preview {
+  border-top: 1px solid rgba(15, 23, 42, 0.1);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.amplisio-preview__body {
+  background: #fff;
+  border-radius: var(--amplisio-radius, 12px);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  padding: 1rem;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.amplisio-dashboard__loading,
+.amplisio-dashboard__empty {
+  color: rgba(15, 23, 42, 0.7);
+  font-style: italic;
+}
+
+@media (prefers-color-scheme: dark) {
+  .amplisio-dashboard__layout,
+  .amplisio-card,
+  .amplisio-form,
+  .amplisio-panel {
+    color: #e2e8f0;
+    background: #0f172a;
+    border-color: rgba(226, 232, 240, 0.1);
+  }
+
+  .amplisio-card,
+  .amplisio-form,
+  .amplisio-panel {
+    box-shadow: none;
+  }
+
+  .amplisio-field input,
+  .amplisio-field textarea,
+  .amplisio-field select {
+    background: rgba(226, 232, 240, 0.1);
+    color: #e2e8f0;
+    border-color: rgba(226, 232, 240, 0.2);
+  }
+}

--- a/build/admin-dashboard.js
+++ b/build/admin-dashboard.js
@@ -1,0 +1,705 @@
+const {
+  root: apiRoot,
+  nonce,
+  modules: initialModules,
+  themeFallbacks = {},
+  themeCssVariables: baseThemeVariables = {},
+} = window.amplisioAioData || {};
+const root = document.getElementById('amplisio-aio-dashboard');
+
+if (root && apiRoot) {
+  const initialAbandoned = {
+    settings: null,
+    loading: false,
+    saving: false,
+    preview: null,
+    message: '',
+    testEmail: '',
+    sendingTest: false,
+  };
+
+  const state = {
+    cards: [],
+    theme: window.amplisioAioData.settings.theme || {},
+    modules: initialModules,
+    loading: false,
+    saving: false,
+    abandoned: { ...initialAbandoned },
+  };
+
+  const translate = (text) => {
+    if (window.wp && window.wp.i18n && typeof window.wp.i18n.__ === 'function') {
+      return window.wp.i18n.__(text, 'amplisio-aio');
+    }
+
+    return text;
+  };
+
+  const fetchJSON = async (path, options = {}) => {
+    const response = await fetch(`${apiRoot}/${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': nonce,
+        ...(options.headers || {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+
+    return response.json();
+  };
+
+  const withAbandoned = (partial) => ({
+    abandoned: {
+      ...state.abandoned,
+      ...partial,
+    },
+  });
+
+  const setState = (partial) => {
+    Object.assign(state, partial);
+    render();
+  };
+
+  const resolveThemeVariable = (key, override) => {
+    const value = typeof override === 'string' ? override.trim() : '';
+    if (value) {
+      return value;
+    }
+
+    return baseThemeVariables[key] || '';
+  };
+
+  const applyThemeVariables = (node) => {
+    const variables = {
+      '--amplisio-font-family': resolveThemeVariable('--amplisio-font-family', state.theme.fontFamily),
+      '--amplisio-primary': resolveThemeVariable('--amplisio-primary', state.theme.primaryColor),
+      '--amplisio-accent': resolveThemeVariable('--amplisio-accent', state.theme.accentColor),
+      '--amplisio-radius': resolveThemeVariable('--amplisio-radius', state.theme.radius),
+    };
+
+    Object.entries(variables).forEach(([name, value]) => {
+      if (value) {
+        node.style.setProperty(name, value);
+      } else {
+        node.style.removeProperty(name);
+      }
+    });
+  };
+
+  const isAbandonedEnabled = () =>
+    state.modules.some((module) => module.id === 'abandoned_cart' && module.enabled);
+
+  const loadDashboard = async () => {
+    try {
+      setState({ loading: true });
+      const data = await fetchJSON('dashboard');
+      setState({ cards: data.cards || [], theme: data.theme || state.theme, loading: false });
+      if (isAbandonedEnabled()) {
+        await loadAbandonedSettings();
+      } else {
+        setState(withAbandoned({ ...initialAbandoned }));
+      }
+    } catch (error) {
+      console.error(error);
+      setState({ loading: false });
+    }
+  };
+
+  const loadAbandonedSettings = async () => {
+    if (!isAbandonedEnabled()) {
+      setState(withAbandoned({ ...initialAbandoned }));
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ loading: true, message: '', preview: null }));
+      const settings = await fetchJSON('abandoned-cart/sequences');
+      setState(withAbandoned({ settings, loading: false }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ loading: false, message: translate('Unable to load abandoned cart settings.') }));
+    }
+  };
+
+  const updateSettings = async (event) => {
+    event.preventDefault();
+    const form = event.target;
+    const formData = new FormData(form);
+    const modulesPayload = {};
+
+    state.modules.forEach((module) => {
+      const field = form.querySelector(`[data-module-id="${module.id}"]`);
+      modulesPayload[module.id] = field ? field.checked : module.enabled;
+    });
+
+    const payload = {
+      theme: {
+        fontFamily: (formData.get('fontFamily') || '').trim(),
+        primaryColor: (formData.get('primaryColor') || '').trim(),
+        accentColor: (formData.get('accentColor') || '').trim(),
+        radius: (formData.get('radius') || '').trim(),
+      },
+      modules: modulesPayload,
+    };
+
+    try {
+      setState({ saving: true });
+      const updated = await fetchJSON('settings', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const modules = state.modules.map((module) => ({
+        ...module,
+        enabled: Boolean(modulesPayload[module.id]),
+      }));
+      setState({
+        theme: updated.theme,
+        modules,
+        saving: false,
+      });
+      if (!modulesPayload.abandoned_cart) {
+        setState(withAbandoned({ ...initialAbandoned }));
+      }
+      await loadDashboard();
+    } catch (error) {
+      console.error(error);
+      setState({ saving: false });
+    }
+  };
+
+  const updateSequenceField = (sequenceId, field, value) => {
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    const settings = {
+      ...state.abandoned.settings,
+      sequences: state.abandoned.settings.sequences.map((sequence) =>
+        sequence.id === sequenceId
+          ? {
+              ...sequence,
+              [field]: value,
+            }
+          : sequence
+      ),
+    };
+
+    setState(withAbandoned({ settings }));
+  };
+
+  const updateTimingField = (field, value) => {
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    const settings = {
+      ...state.abandoned.settings,
+      [field]: value,
+    };
+
+    setState(withAbandoned({ settings }));
+  };
+
+  const saveSequences = async (event) => {
+    event.preventDefault();
+    if (!state.abandoned.settings) {
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ saving: true, message: '' }));
+      const updated = await fetchJSON('abandoned-cart/sequences', {
+        method: 'POST',
+        body: JSON.stringify(state.abandoned.settings),
+      });
+      setState(withAbandoned({ settings: updated, saving: false, message: translate('Sequences saved.') }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ saving: false, message: translate('Unable to save sequences.') }));
+    }
+  };
+
+  const previewSequence = async (sequenceId) => {
+    try {
+      setState(withAbandoned({ message: '', preview: { loading: true } }));
+      const preview = await fetchJSON('abandoned-cart/preview', {
+        method: 'POST',
+        body: JSON.stringify({ sequenceId }),
+      });
+      setState(withAbandoned({ preview, message: '' }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ preview: null, message: translate('Unable to generate preview.') }));
+    }
+  };
+
+  const sendTest = async (sequenceId) => {
+    if (!state.abandoned.testEmail) {
+      setState(withAbandoned({ message: translate('Enter a test email before sending.'), preview: state.abandoned.preview }));
+      return;
+    }
+
+    try {
+      setState(withAbandoned({ sendingTest: true, message: '' }));
+      await fetchJSON('abandoned-cart/test', {
+        method: 'POST',
+        body: JSON.stringify({ sequenceId, email: state.abandoned.testEmail }),
+      });
+      setState(withAbandoned({ sendingTest: false, message: translate('Test email sent.') }));
+    } catch (error) {
+      console.error(error);
+      setState(withAbandoned({ sendingTest: false, message: translate('Unable to send test email.') }));
+    }
+  };
+
+  const createCard = (card) => {
+    const article = document.createElement('article');
+    article.className = 'amplisio-card';
+    article.setAttribute('role', 'group');
+    article.setAttribute('aria-label', card.title);
+
+    const title = document.createElement('h3');
+    title.textContent = card.title;
+    title.className = 'amplisio-card__title';
+    article.appendChild(title);
+
+    const value = document.createElement('p');
+    value.className = 'amplisio-card__value';
+    value.textContent = card.value;
+    article.appendChild(value);
+
+    const description = document.createElement('p');
+    description.className = 'amplisio-card__description';
+    description.textContent = card.description;
+    article.appendChild(description);
+
+    return article;
+  };
+
+  const renderCards = () => {
+    const section = document.createElement('section');
+    section.className = 'amplisio-grid';
+    section.setAttribute('aria-live', 'polite');
+
+    if (state.loading) {
+      const loader = document.createElement('p');
+      loader.textContent = translate('Loading metrics…');
+      loader.className = 'amplisio-dashboard__loading';
+      section.appendChild(loader);
+      return section;
+    }
+
+    if (!state.cards.length) {
+      const empty = document.createElement('p');
+      empty.textContent = translate('No data available yet.');
+      empty.className = 'amplisio-dashboard__empty';
+      section.appendChild(empty);
+      return section;
+    }
+
+    state.cards.forEach((card) => {
+      section.appendChild(createCard(card));
+    });
+
+    return section;
+  };
+
+  const renderThemeForm = () => {
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'amplisio-fieldset';
+
+    const legend = document.createElement('legend');
+    legend.textContent = translate('Theme');
+    fieldset.appendChild(legend);
+
+    const fields = [
+      {
+        label: translate('Font family'),
+        name: 'fontFamily',
+        type: 'text',
+        value: state.theme.fontFamily || '',
+        placeholder: themeFallbacks.fontFamily || '"Inter", sans-serif',
+      },
+      {
+        label: translate('Primary color'),
+        name: 'primaryColor',
+        type: 'text',
+        value: state.theme.primaryColor || '',
+        placeholder: themeFallbacks.primaryColor || '#2563eb',
+      },
+      {
+        label: translate('Accent color'),
+        name: 'accentColor',
+        type: 'text',
+        value: state.theme.accentColor || '',
+        placeholder: themeFallbacks.accentColor || '#ec4899',
+      },
+      {
+        label: translate('Border radius'),
+        name: 'radius',
+        type: 'text',
+        value: state.theme.radius || '',
+        placeholder: themeFallbacks.radius || '12px',
+      },
+    ];
+
+    fields.forEach((field) => {
+      const wrapper = document.createElement('label');
+      wrapper.className = 'amplisio-field';
+      wrapper.textContent = field.label;
+      const input = document.createElement('input');
+      input.name = field.name;
+      input.type = field.type;
+      input.value = field.value || '';
+      if (field.placeholder) {
+        input.placeholder = field.placeholder;
+      }
+      input.autocomplete = 'off';
+      input.spellcheck = false;
+      input.setAttribute('aria-label', field.label);
+      wrapper.appendChild(input);
+      fieldset.appendChild(wrapper);
+    });
+
+    return fieldset;
+  };
+
+  const renderModuleToggles = () => {
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'amplisio-fieldset';
+
+    const legend = document.createElement('legend');
+    legend.textContent = translate('Modules');
+    fieldset.appendChild(legend);
+
+    state.modules.forEach((module) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'amplisio-toggle';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.id = `module-${module.id}`;
+      input.checked = module.enabled;
+      input.dataset.moduleId = module.id;
+      input.setAttribute('role', 'switch');
+      input.setAttribute('aria-checked', String(module.enabled));
+      input.addEventListener('change', () => {
+        input.setAttribute('aria-checked', String(input.checked));
+      });
+
+      const label = document.createElement('label');
+      label.setAttribute('for', input.id);
+      label.textContent = module.name;
+
+      wrapper.appendChild(input);
+      wrapper.appendChild(label);
+      fieldset.appendChild(wrapper);
+    });
+
+    return fieldset;
+  };
+
+  const createSequenceField = (sequence, label, name, config = {}) => {
+    const { type = 'text', options = [] } = config;
+    const field = document.createElement('label');
+    field.className = 'amplisio-field amplisio-field--stacked';
+    field.textContent = label;
+
+    let input;
+    if ('textarea' === type) {
+      input = document.createElement('textarea');
+    } else if ('select' === type) {
+      input = document.createElement('select');
+      options.forEach((option) => {
+        const opt = document.createElement('option');
+        opt.value = option;
+        opt.textContent = option;
+        if (sequence[name] === option) {
+          opt.selected = true;
+        }
+        input.appendChild(opt);
+      });
+    } else {
+      input = document.createElement('input');
+      input.type = type;
+    }
+
+    if ('checkbox' === type) {
+      input.checked = Boolean(sequence[name]);
+      input.addEventListener('change', (event) => {
+        updateSequenceField(sequence.id, name, event.target.checked);
+      });
+    } else if ('number' === type) {
+      input.value = sequence[name] ?? 0;
+      input.addEventListener('input', (event) => {
+        const numeric = event.target.valueAsNumber;
+        const value = Number.isNaN(numeric) ? 0 : Math.max(0, numeric);
+        updateSequenceField(sequence.id, name, value);
+      });
+    } else if ('select' === type) {
+      input.addEventListener('change', (event) => {
+        updateSequenceField(sequence.id, name, event.target.value);
+      });
+    } else {
+      input.value = sequence[name] ?? '';
+      input.addEventListener('input', (event) => {
+        updateSequenceField(sequence.id, name, event.target.value);
+      });
+    }
+
+    input.setAttribute('aria-label', label);
+    input.dataset.sequenceField = `${sequence.id}-${name}`;
+
+    field.appendChild(input);
+    return field;
+  };
+
+  const renderSequence = (sequence) => {
+    const container = document.createElement('article');
+    container.className = 'amplisio-sequence';
+
+    const header = document.createElement('header');
+    header.className = 'amplisio-sequence__header';
+    const title = document.createElement('h4');
+    title.textContent = sequence.name || sequence.id;
+    header.appendChild(title);
+    container.appendChild(header);
+
+    container.appendChild(createSequenceField(sequence, translate('Delay (minutes)'), 'delay', { type: 'number' }));
+    container.appendChild(createSequenceField(sequence, translate('Email subject'), 'subject'));
+
+    const bodyField = createSequenceField(sequence, translate('Email body'), 'body', { type: 'textarea' });
+    container.appendChild(bodyField);
+
+    const variables = document.createElement('p');
+    variables.className = 'amplisio-sequence__variables';
+    variables.textContent = translate('Available variables: {{first_name}}, {{cart_link}}, {{coupon}}');
+    container.appendChild(variables);
+
+    const couponWrapper = document.createElement('div');
+    couponWrapper.className = 'amplisio-sequence__coupon';
+
+    const couponToggle = createSequenceField(sequence, translate('Generate coupon automatically'), 'autoCoupon', { type: 'checkbox' });
+    couponWrapper.appendChild(couponToggle);
+
+    couponWrapper.appendChild(
+      createSequenceField(sequence, translate('Coupon type'), 'couponType', {
+        type: 'select',
+        options: ['percent', 'fixed_cart', 'fixed_product'],
+      })
+    );
+    couponWrapper.appendChild(createSequenceField(sequence, translate('Coupon amount'), 'couponAmount', { type: 'number' }));
+    couponWrapper.appendChild(
+      createSequenceField(sequence, translate('Coupon expiry (days)'), 'couponExpiryDays', { type: 'number' })
+    );
+
+    container.appendChild(couponWrapper);
+
+    const actions = document.createElement('div');
+    actions.className = 'amplisio-sequence__actions';
+
+    const previewButton = document.createElement('button');
+    previewButton.type = 'button';
+    previewButton.className = 'amplisio-button amplisio-button--ghost';
+    previewButton.textContent = translate('Preview');
+    previewButton.addEventListener('click', () => previewSequence(sequence.id));
+    actions.appendChild(previewButton);
+
+    const testButton = document.createElement('button');
+    testButton.type = 'button';
+    testButton.className = 'amplisio-button amplisio-button--ghost';
+    testButton.textContent = state.abandoned.sendingTest
+      ? translate('Sending…')
+      : translate('Send test');
+    testButton.disabled = state.abandoned.sendingTest;
+    testButton.addEventListener('click', () => sendTest(sequence.id));
+    actions.appendChild(testButton);
+
+    container.appendChild(actions);
+
+    return container;
+  };
+
+  const renderTimingControls = () => {
+    if (!state.abandoned.settings) {
+      return document.createDocumentFragment();
+    }
+
+    const container = document.createElement('article');
+    container.className = 'amplisio-sequence amplisio-sequence--settings';
+
+    const heading = document.createElement('h4');
+    heading.textContent = translate('Sequence timing');
+    container.appendChild(heading);
+
+    const abandonField = document.createElement('label');
+    abandonField.className = 'amplisio-field amplisio-field--stacked';
+    abandonField.textContent = translate('Mark abandoned after (minutes)');
+    const abandonInput = document.createElement('input');
+    abandonInput.type = 'number';
+    abandonInput.min = '5';
+    abandonInput.value = state.abandoned.settings.abandonAfterMinutes;
+    abandonInput.addEventListener('input', (event) => {
+      const numeric = event.target.valueAsNumber;
+      const value = Number.isNaN(numeric) ? state.abandoned.settings.abandonAfterMinutes : Math.max(5, numeric);
+      updateTimingField('abandonAfterMinutes', value);
+    });
+    abandonField.appendChild(abandonInput);
+    container.appendChild(abandonField);
+
+    const expireField = document.createElement('label');
+    expireField.className = 'amplisio-field amplisio-field--stacked';
+    expireField.textContent = translate('Expire abandoned carts after (days)');
+    const expireInput = document.createElement('input');
+    expireInput.type = 'number';
+    expireInput.min = '1';
+    expireInput.value = state.abandoned.settings.expireAfterDays;
+    expireInput.addEventListener('input', (event) => {
+      const numeric = event.target.valueAsNumber;
+      const value = Number.isNaN(numeric) ? state.abandoned.settings.expireAfterDays : Math.max(1, numeric);
+      updateTimingField('expireAfterDays', value);
+    });
+    expireField.appendChild(expireInput);
+    container.appendChild(expireField);
+
+    return container;
+  };
+
+  const renderAbandonedSequences = () => {
+    const panel = document.createElement('section');
+    panel.className = 'amplisio-panel';
+
+    const heading = document.createElement('h3');
+    heading.textContent = translate('Abandoned cart sequences');
+    panel.appendChild(heading);
+
+    if (!isAbandonedEnabled()) {
+      const disabled = document.createElement('p');
+      disabled.textContent = translate('Enable the abandoned cart module to manage recovery emails.');
+      disabled.className = 'amplisio-panel__notice';
+      panel.appendChild(disabled);
+      return panel;
+    }
+
+    if (state.abandoned.loading) {
+      const loading = document.createElement('p');
+      loading.textContent = translate('Loading sequences…');
+      loading.className = 'amplisio-panel__notice';
+      panel.appendChild(loading);
+      return panel;
+    }
+
+    if (!state.abandoned.settings) {
+      const empty = document.createElement('p');
+      empty.textContent = translate('No sequences configured yet.');
+      empty.className = 'amplisio-panel__notice';
+      panel.appendChild(empty);
+      return panel;
+    }
+
+    const form = document.createElement('form');
+    form.className = 'amplisio-panel__form';
+    form.addEventListener('submit', saveSequences);
+
+    form.appendChild(renderTimingControls());
+
+    state.abandoned.settings.sequences.forEach((sequence) => {
+      form.appendChild(renderSequence(sequence));
+    });
+
+    const testField = document.createElement('label');
+    testField.className = 'amplisio-field amplisio-field--stacked';
+    testField.textContent = translate('Test email address');
+    const testInput = document.createElement('input');
+    testInput.type = 'email';
+    testInput.value = state.abandoned.testEmail;
+    testInput.placeholder = translate('name@example.com');
+    testInput.setAttribute('aria-label', translate('Test email address'));
+    testInput.addEventListener('input', (event) => {
+      setState(withAbandoned({ testEmail: event.target.value }));
+    });
+    testField.appendChild(testInput);
+    form.appendChild(testField);
+
+    const save = document.createElement('button');
+    save.type = 'submit';
+    save.className = 'amplisio-button';
+    save.textContent = state.abandoned.saving ? translate('Saving…') : translate('Save sequences');
+    save.disabled = state.abandoned.saving;
+    form.appendChild(save);
+
+    if (state.abandoned.message) {
+      const message = document.createElement('p');
+      message.className = 'amplisio-panel__message';
+      message.textContent = state.abandoned.message;
+      form.appendChild(message);
+    }
+
+    if (state.abandoned.preview && state.abandoned.preview.loading) {
+      const loading = document.createElement('p');
+      loading.className = 'amplisio-panel__notice';
+      loading.textContent = translate('Generating preview…');
+      form.appendChild(loading);
+    }
+
+    if (state.abandoned.preview && !state.abandoned.preview.loading) {
+      const preview = document.createElement('section');
+      preview.className = 'amplisio-preview';
+
+      const subject = document.createElement('h4');
+      subject.textContent = `${translate('Subject')}: ${state.abandoned.preview.subject || ''}`;
+      preview.appendChild(subject);
+
+      const body = document.createElement('div');
+      body.className = 'amplisio-preview__body';
+      body.innerHTML = state.abandoned.preview.body || '';
+      preview.appendChild(body);
+
+      form.appendChild(preview);
+    }
+
+    panel.appendChild(form);
+
+    return panel;
+  };
+
+  const render = () => {
+    root.innerHTML = '';
+
+    const layout = document.createElement('div');
+    layout.className = 'amplisio-dashboard__layout';
+    applyThemeVariables(layout);
+
+    const cardsSection = renderCards();
+    layout.appendChild(cardsSection);
+
+    const form = document.createElement('form');
+    form.className = 'amplisio-form';
+    form.addEventListener('submit', updateSettings);
+
+    form.appendChild(renderThemeForm());
+    form.appendChild(renderModuleToggles());
+
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.className = 'amplisio-button';
+    submit.textContent = state.saving ? translate('Saving…') : translate('Save changes');
+    submit.disabled = state.saving;
+    form.appendChild(submit);
+
+    layout.appendChild(form);
+
+    if (isAbandonedEnabled()) {
+      layout.appendChild(renderAbandonedSequences());
+    }
+
+    root.appendChild(layout);
+  };
+
+  render();
+  loadDashboard();
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "amplisio/aio",
+  "description": "Amplisio AIO for WooCommerce",
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=8.1",
+    "woocommerce/action-scheduler": "^3.6"
+  },
+  "autoload": {
+    "psr-4": {
+      "Amplisio\\AIO\\": "src/"
+    }
+  },
+  "scripts": {
+    "post-autoload-dump": [
+      "@php -r \"file_exists('vendor/autoload.php') || exit(0);\""
+    ]
+  }
+}

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const esbuild = require('esbuild');
+
+const isWatch = process.argv.includes('--watch');
+
+esbuild.build({
+  entryPoints: ['assets/js/admin/dashboard.js'],
+  bundle: true,
+  outfile: 'build/admin-dashboard.js',
+  minify: !isWatch,
+  sourcemap: isWatch,
+  target: ['es2020'],
+  platform: 'browser',
+}).then(() => {
+  if (!isWatch) {
+    console.log('Build complete');
+  }
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/languages/amplisio-aio.pot
+++ b/languages/amplisio-aio.pot
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Amplisio AIO 1.0.0\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Amplisio\n"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "amplisio-aio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "watch": "node esbuild.config.js --watch"
+  },
+  "devDependencies": {
+    "esbuild": "^0.19.12"
+  }
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="Amplisio AIO">
+    <description>WordPress Coding Standards for Amplisio AIO.</description>
+    <file>./amplisio-aio.php</file>
+    <file>./src</file>
+    <rule ref="WordPress-Core" />
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra" />
+    <config name="installed_paths" value="vendor/wp-coding-standards/wpcs" />
+    <arg value="-s" />
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Amplisio AIO Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,0 @@
-echo "# Amplisio-AIO-Shopify" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/gedasgmpt/Amplisio-AIO-Shopify.git
-git push -u origin main

--- a/src/CLI/Commands/ModuleToggleCommand.php
+++ b/src/CLI/Commands/ModuleToggleCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Amplisio\AIO\CLI\Commands;
+
+use Amplisio\AIO\Modules\ModuleManager;
+use WP_CLI_Command;
+
+class ModuleToggleCommand extends WP_CLI_Command
+{
+    public function __construct(private ModuleManager $modules)
+    {
+    }
+
+    /**
+     * Toggle module state.
+     *
+     * ## OPTIONS
+     *
+     * <action>
+     * : Action to perform (enable or disable).
+     *
+     * <module>
+     * : Module identifier.
+     */
+    public function __invoke(string $action, string $module_id): void
+    {
+        $module_id = sanitize_key($module_id);
+        $modules   = $this->modules->get_modules();
+
+        if ( ! isset($modules[$module_id]) ) {
+            \WP_CLI::error(sprintf('Module "%s" is not registered.', $module_id));
+            return;
+        }
+
+        $enable = 'enable' === strtolower($action);
+
+        $this->modules->set_module_status($module_id, $enable);
+
+        \WP_CLI::success(sprintf('%s %s', $enable ? 'Enabled' : 'Disabled', $modules[$module_id]->get_name()));
+    }
+}

--- a/src/CLI/Commands/StatusCommand.php
+++ b/src/CLI/Commands/StatusCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Amplisio\AIO\CLI\Commands;
+
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Repositories\OptionRepository;
+use WP_CLI_Command;
+
+class StatusCommand extends WP_CLI_Command
+{
+    public function __construct(private ModuleManager $modules, private OptionRepository $options)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        \WP_CLI::log('Amplisio AIO v' . AMPLISIO_AIO_VERSION);
+        \WP_CLI::log('Active modules:');
+
+        foreach ($this->modules->get_modules() as $module) {
+            $status = $this->options->is_module_enabled($module->get_id()) ? 'enabled' : 'disabled';
+            \WP_CLI::log(sprintf('- %s (%s)', $module->get_name(), $status));
+        }
+    }
+}

--- a/src/Modules/AbandonedCart/AbandonedCartModule.php
+++ b/src/Modules/AbandonedCart/AbandonedCartModule.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace Amplisio\AIO\Modules\AbandonedCart;
+
+use Amplisio\AIO\Modules\AbstractModule;
+use Amplisio\AIO\Services\Container;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Cart;
+use WC_Order;
+
+use function __;
+use function WC;
+use function add_action;
+use function add_filter;
+use function add_query_arg;
+use function apply_filters;
+use function as_next_scheduled_action;
+use function as_schedule_single_action;
+use function esc_url;
+use function is_user_logged_in;
+use function number_format_i18n;
+use function sanitize_key;
+use function sanitize_text_field;
+use function wc_add_notice;
+use function wc_get_cart_url;
+use function wc_get_order;
+use function wc_price;
+use function wp_json_encode;
+use function wp_mail;
+use function wp_unslash;
+
+class AbandonedCartModule extends AbstractModule
+{
+    private ?AbandonedCartService $service = null;
+
+    private ?AbandonedCartSequenceRepository $sequences = null;
+
+    private bool $hpos_enabled = false;
+
+    public function get_id(): string
+    {
+        return 'abandoned_cart';
+    }
+
+    public function get_name(): string
+    {
+        return __('Abandoned cart recovery', 'amplisio-aio');
+    }
+
+    public function get_rest_base(): string
+    {
+        return 'abandoned-cart';
+    }
+
+    public function register(Container $container): void
+    {
+        $container->singleton(AbandonedCartService::class, static fn (): AbandonedCartService => new AbandonedCartService($GLOBALS['wpdb']));
+        $container->singleton(AbandonedCartSequenceRepository::class, static fn (): AbandonedCartSequenceRepository => new AbandonedCartSequenceRepository());
+    }
+
+    public function boot(Container $container): void
+    {
+        $this->service      = $container->get(AbandonedCartService::class);
+        $this->sequences    = $container->get(AbandonedCartSequenceRepository::class);
+        $this->hpos_enabled = $this->is_hpos_enabled();
+
+        $this->service->maybe_create_table();
+
+        add_action('woocommerce_cart_updated', [$this, 'capture_cart_from_session']);
+        add_action('woocommerce_cart_loaded_from_session', [$this, 'capture_cart_from_session']);
+        add_action('woocommerce_add_to_cart', [$this, 'capture_cart_from_session']);
+        if ($this->hpos_enabled) {
+            add_action('woocommerce_checkout_create_order', [$this, 'store_order_meta'], 10, 2);
+        }
+        add_action('woocommerce_checkout_order_processed', [$this, 'handle_order_processed'], 10, 3);
+        add_action('wp', [$this, 'maybe_restore_cart']);
+
+        add_filter('wp_privacy_personal_data_exporters', [$this, 'register_privacy_exporter']);
+        add_filter('wp_privacy_personal_data_erasers', [$this, 'register_privacy_eraser']);
+
+        add_action('rest_api_init', function (): void {
+            (new AbandonedCartRestController($this->service, $this->sequences))->register_routes();
+        });
+
+        add_action('amplisio_aio_abandoned_sequence', [$this, 'dispatch_sequence_email'], 10, 2);
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'enabled' => false,
+        ];
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        $stats = $this->service?->get_stats() ?? ['counts' => ['abandoned' => 0, 'recovered' => 0, 'active' => 0, 'expired' => 0], 'revenue' => 0];
+
+        return [
+            [
+                'id'          => 'abandoned-carts',
+                'title'       => __('Abandoned carts', 'amplisio-aio'),
+                'value'       => number_format_i18n($stats['counts']['abandoned'] ?? 0),
+                'description' => __('Carts requiring follow-up', 'amplisio-aio'),
+            ],
+            [
+                'id'          => 'recovered-carts-total',
+                'title'       => __('Recovered revenue', 'amplisio-aio'),
+                'value'       => wc_price($stats['revenue'] ?? 0),
+                'description' => __('Total revenue from recovery sequences', 'amplisio-aio'),
+            ],
+        ];
+    }
+
+    public function run_scheduled_event(): void
+    {
+        $service   = $this->service ?? new AbandonedCartService($GLOBALS['wpdb']);
+        $repository = $this->sequences ?? new AbandonedCartSequenceRepository();
+        $settings  = $repository->get_settings();
+        $sequences = $settings['sequences'];
+
+        $service->mark_carts_abandoned((int) $settings['abandonAfterMinutes'], function (array $cart) use ($sequences): void {
+            if ( ! function_exists('as_schedule_single_action') ) {
+                return;
+            }
+
+            foreach ($sequences as $sequence) {
+                $sequence_id = sanitize_key($sequence['id']);
+                if ( ! $sequence_id ) {
+                    continue;
+                }
+
+                $timestamp = strtotime($cart['abandoned_at']) + ((int) $sequence['delay'] * MINUTE_IN_SECONDS);
+                if ( ! empty($cart['sequence_log']) ) {
+                    $events = json_decode((string) $cart['sequence_log'], true);
+                    if (is_array($events)) {
+                        foreach ($events as $event) {
+                            if (('sent' === ($event['type'] ?? '')) && $event['sequence_id'] === $sequence_id) {
+                                continue 2;
+                            }
+                        }
+                    }
+                }
+
+                if (function_exists('as_next_scheduled_action')) {
+                    $next = as_next_scheduled_action('amplisio_aio_abandoned_sequence', [$cart['id'], $sequence_id], 'amplisio-aio');
+                    if ($next) {
+                        continue;
+                    }
+                }
+
+                if ($timestamp <= time()) {
+                    $timestamp = time() + MINUTE_IN_SECONDS;
+                }
+
+                as_schedule_single_action($timestamp, 'amplisio_aio_abandoned_sequence', [$cart['id'], $sequence_id], 'amplisio-aio');
+            }
+        });
+
+        $service->expire_abandoned_carts((int) $settings['expireAfterDays']);
+    }
+
+    public function capture_cart_from_session(): void
+    {
+        if ( ! function_exists('WC') ) {
+            return;
+        }
+
+        $wc = WC();
+        if ( ! $wc || ! $wc->cart instanceof WC_Cart || ! $wc->session ) {
+            return;
+        }
+
+        $cart = $wc->cart;
+        if ($cart->is_empty()) {
+            return;
+        }
+
+        $session_id = (string) $wc->session->get_customer_id();
+        if ('' === $session_id) {
+            return;
+        }
+
+        $items = [];
+        foreach ($cart->get_cart() as $item) {
+            $product = $item['data'] ?? null;
+            $items[] = [
+                'product_id'   => isset($item['product_id']) ? (int) $item['product_id'] : 0,
+                'variation_id' => isset($item['variation_id']) ? (int) $item['variation_id'] : 0,
+                'quantity'     => isset($item['quantity']) ? (int) $item['quantity'] : 0,
+                'name'         => $product ? $product->get_name() : ($item['name'] ?? ''),
+            ];
+        }
+
+        if ( ! $items ) {
+            return;
+        }
+
+        $customer   = $wc->customer;
+        $email      = $customer ? $customer->get_email() : '';
+        $first_name = $customer ? $customer->get_first_name() : '';
+
+        $settings = $this->sequences?->get_settings() ?? (new AbandonedCartSequenceRepository())->get_default_settings();
+        $consent  = apply_filters('amplisio_aio_abandoned_cart_consent', is_user_logged_in() && (bool) $email, $cart, $customer);
+
+        $this->service?->record_cart($session_id, [
+            'email'      => $email,
+            'first_name' => $first_name,
+            'subtotal'   => (float) $cart->get_subtotal(),
+            'items'      => $items,
+            'consent'    => $consent,
+            'expires_at' => gmdate('Y-m-d H:i:s', time() + ((int) $settings['expireAfterDays'] * DAY_IN_SECONDS)),
+        ]);
+    }
+
+    public function store_order_meta(WC_Order $order, array $data): void
+    {
+        if ( ! $this->hpos_enabled || ! function_exists('WC') ) {
+            return;
+        }
+
+        $wc = WC();
+        if ( ! $wc || ! $wc->session ) {
+            return;
+        }
+
+        $cart_key = (string) $wc->session->get_customer_id();
+        if ($cart_key) {
+            $order->update_meta_data('_amplisio_cart_key', $cart_key);
+        }
+    }
+
+    public function handle_order_processed(int $order_id, array $posted_data, WC_Order $order): void
+    {
+        if ( ! $order instanceof WC_Order ) {
+            if (function_exists('wc_get_order')) {
+                $order = wc_get_order($order_id);
+            }
+
+            if ( ! $order instanceof WC_Order ) {
+                return;
+            }
+        }
+
+        $cart_key = $this->hpos_enabled ? (string) $order->get_meta('_amplisio_cart_key') : '';
+        $cart     = $cart_key ? $this->service?->get_cart_by_key($cart_key) : null;
+
+        if (null === $cart && $order->get_billing_email()) {
+            $matches = $this->service?->find_carts_for_email($order->get_billing_email()) ?? [];
+            foreach ($matches as $candidate) {
+                if ('recovered' === $candidate['status']) {
+                    continue;
+                }
+                $cart = $candidate;
+                break;
+            }
+        }
+
+        if (null === $cart) {
+            return;
+        }
+
+        $this->service?->mark_recovered(
+            (int) $cart['id'],
+            $order_id,
+            (float) $order->get_total(),
+            (string) $order->get_billing_email(),
+            (string) $order->get_billing_first_name()
+        );
+    }
+
+    public function maybe_restore_cart(): void
+    {
+        if ( ! function_exists('WC') || ! isset($_GET['amplisio_cart'], $_GET['amplisio_token']) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return;
+        }
+
+        $cart_key = sanitize_text_field(wp_unslash((string) $_GET['amplisio_cart'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $token    = sanitize_text_field(wp_unslash((string) $_GET['amplisio_token'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        if ('' === $cart_key || '' === $token) {
+            return;
+        }
+
+        $payload = $this->service?->get_restore_payload($cart_key, $token);
+        if ( ! $payload ) {
+            return;
+        }
+
+        $wc = WC();
+        if ( ! $wc || ! $wc->cart instanceof WC_Cart ) {
+            return;
+        }
+
+        $cart = $wc->cart;
+        $cart->empty_cart();
+
+        foreach ($payload['items'] as $item) {
+            if (empty($item['product_id'])) {
+                continue;
+            }
+
+            $product_id   = (int) $item['product_id'];
+            $variation_id = isset($item['variation_id']) ? (int) $item['variation_id'] : 0;
+            $quantity     = max(1, (int) ($item['quantity'] ?? 1));
+
+            if ($variation_id) {
+                $cart->add_to_cart($product_id, $quantity, $variation_id);
+            } else {
+                $cart->add_to_cart($product_id, $quantity);
+            }
+        }
+
+        if ( ! empty($payload['coupon_code']) ) {
+            $cart->apply_coupon(sanitize_text_field($payload['coupon_code']));
+        }
+
+        wc_add_notice(__('Your cart has been restored. Continue checkout to complete your purchase.', 'amplisio-aio'), 'success');
+    }
+
+    public function register_privacy_exporter(array $exporters): array
+    {
+        $exporters['amplisio-aio-abandoned-cart'] = [
+            'exporter_friendly_name' => __('Amplisio AIO Abandoned Cart', 'amplisio-aio'),
+            'callback'               => [$this, 'export_personal_data'],
+        ];
+
+        return $exporters;
+    }
+
+    public function register_privacy_eraser(array $erasers): array
+    {
+        $erasers['amplisio-aio-abandoned-cart'] = [
+            'eraser_friendly_name' => __('Amplisio AIO Abandoned Cart', 'amplisio-aio'),
+            'callback'             => [$this, 'erase_personal_data'],
+        ];
+
+        return $erasers;
+    }
+
+    public function export_personal_data(string $email, int $page): array
+    {
+        $records = $this->service?->find_carts_for_email($email) ?? [];
+        $data    = [];
+
+        foreach ($records as $record) {
+            $items = json_decode((string) $record['items'], true);
+            if ( ! is_array($items) ) {
+                $items = [];
+            }
+
+            $data[] = [
+                'group_id'    => 'amplisio-aio-abandoned-cart',
+                'group_label' => __('Amplisio AIO Abandoned Cart', 'amplisio-aio'),
+                'item_id'     => 'amplisio-cart-' . (int) $record['id'],
+                'data'        => [
+                    [
+                        'name'  => __('Status', 'amplisio-aio'),
+                        'value' => $record['status'],
+                    ],
+                    [
+                        'name'  => __('Last updated', 'amplisio-aio'),
+                        'value' => $record['updated_at'],
+                    ],
+                    [
+                        'name'  => __('Items', 'amplisio-aio'),
+                        'value' => wp_json_encode($items),
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'data' => $data,
+            'done' => true,
+        ];
+    }
+
+    public function erase_personal_data(string $email, int $page): array
+    {
+        $count = $this->service?->erase_carts_for_email($email) ?? 0;
+
+        return [
+            'items_removed'  => $count > 0,
+            'items_retained' => false,
+            'messages'       => [],
+        ];
+    }
+
+    public function dispatch_sequence_email(int $cart_id, string $sequence_id): void
+    {
+        $service   = $this->service ?? new AbandonedCartService($GLOBALS['wpdb']);
+        $repository = $this->sequences ?? new AbandonedCartSequenceRepository();
+
+        $cart = $service->get_cart($cart_id);
+        if ( ! $cart || 'abandoned' !== $cart['status'] || empty($cart['email']) ) {
+            return;
+        }
+
+        $sequence = $this->find_sequence($repository->get_sequences(), $sequence_id);
+        if ( ! $sequence ) {
+            return;
+        }
+
+        if ( ! empty($cart['sequence_log']) ) {
+            $events = json_decode((string) $cart['sequence_log'], true);
+            if (is_array($events)) {
+                foreach ($events as $event) {
+                    if (('sent' === ($event['type'] ?? '')) && $event['sequence_id'] === $sequence_id) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        $coupon = null;
+        if ( ! empty($sequence['autoCoupon']) ) {
+            $coupon = $service->issue_coupon_for_cart($cart_id, (string) $cart['email'], $sequence);
+        } elseif ( ! empty($cart['coupon_code']) ) {
+            $coupon = [
+                'code'       => $cart['coupon_code'],
+                'expires_at' => $cart['coupon_expires_at'],
+            ];
+        }
+
+        $replacements = [
+            '{{first_name}}' => $cart['first_name'] ?: __('there', 'amplisio-aio'),
+            '{{cart_link}}'  => esc_url(add_query_arg(
+                [
+                    'amplisio_cart'  => $cart['cart_key'],
+                    'amplisio_token' => $cart['restore_token'],
+                ],
+                wc_get_cart_url()
+            )),
+            '{{coupon}}'     => $coupon['code'] ?? '',
+        ];
+
+        $subject = strtr($sequence['subject'], $replacements);
+        $body    = strtr($sequence['body'], $replacements);
+
+        $headers = apply_filters('amplisio_aio_abandoned_cart_email_headers', ['Content-Type: text/html; charset=UTF-8']);
+        $sent    = wp_mail($cart['email'], $subject, $body, $headers);
+
+        if ($sent) {
+            $service->log_sequence_event($cart_id, [
+                'type'        => 'sent',
+                'sequence_id' => $sequence_id,
+                'coupon_code' => $coupon['code'] ?? null,
+            ]);
+        }
+    }
+
+    private function find_sequence(array $sequences, string $sequence_id): ?array
+    {
+        foreach ($sequences as $sequence) {
+            if (sanitize_key($sequence['id']) === sanitize_key($sequence_id)) {
+                return $sequence;
+            }
+        }
+
+        return null;
+    }
+
+    private function is_hpos_enabled(): bool
+    {
+        if (class_exists(OrderUtil::class)) {
+            return OrderUtil::custom_orders_table_usage_is_enabled();
+        }
+
+        return false;
+    }
+}

--- a/src/Modules/AbandonedCart/AbandonedCartRestController.php
+++ b/src/Modules/AbandonedCart/AbandonedCartRestController.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Amplisio\AIO\Modules\AbandonedCart;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+
+use function __;
+use function add_query_arg;
+use function apply_filters;
+use function current_user_can;
+use function esc_url;
+use function register_rest_route;
+use function rest_authorization_required_code;
+use function sanitize_email;
+use function sanitize_text_field;
+use function wc_get_cart_url;
+use function wc_price;
+use function wp_mail;
+use function wp_kses_post;
+
+class AbandonedCartRestController extends WP_REST_Controller
+{
+    public function __construct(private AbandonedCartService $service, private AbandonedCartSequenceRepository $repository)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'abandoned-cart';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/stats',
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_stats'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/recoveries',
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_recoveries'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/top-products',
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_top_products'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/sequences',
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_sequences'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'update_sequences'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/sequence-performance',
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_sequence_performance'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/preview',
+            [
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'preview_sequence'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/test',
+            [
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'send_test'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to access abandoned cart data.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_stats(): WP_REST_Response
+    {
+        $stats = $this->service->get_stats();
+        $stats['revenue_formatted'] = function_exists('wc_price') ? wc_price($stats['revenue']) : $stats['revenue'];
+
+        return new WP_REST_Response($stats);
+    }
+
+    public function get_recoveries(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->service->get_recent_recoveries());
+    }
+
+    public function get_top_products(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->service->get_top_products());
+    }
+
+    public function get_sequences(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->repository->get_settings());
+    }
+
+    public function update_sequences(WP_REST_Request $request): WP_REST_Response
+    {
+        $data = json_decode($request->get_body(), true);
+        if ( ! is_array($data) ) {
+            $data = [];
+        }
+
+        $this->repository->update_settings($data);
+
+        return new WP_REST_Response($this->repository->get_settings());
+    }
+
+    public function get_sequence_performance(): WP_REST_Response
+    {
+        $settings = $this->repository->get_settings();
+        $data     = $this->service->get_sequence_performance($settings['sequences']);
+
+        return new WP_REST_Response($data);
+    }
+
+    public function preview_sequence(WP_REST_Request $request): WP_REST_Response
+    {
+        $params   = $this->parse_json_body($request);
+        $sequence = $this->find_sequence($params);
+        if ( ! $sequence ) {
+            return new WP_REST_Response(['message' => __('Sequence not found.', 'amplisio-aio')], 404);
+        }
+
+        $sample = $this->render_template($sequence, [
+            'first_name' => __('there', 'amplisio-aio'),
+            'cart_link'  => esc_url(add_query_arg([], wc_get_cart_url())),
+            'coupon'     => __('SAVE10', 'amplisio-aio'),
+        ]);
+
+        return new WP_REST_Response($sample);
+    }
+
+    public function send_test(WP_REST_Request $request): WP_REST_Response
+    {
+        $params   = $this->parse_json_body($request);
+        $sequence = $this->find_sequence($params);
+        if ( ! $sequence ) {
+            return new WP_REST_Response(['message' => __('Sequence not found.', 'amplisio-aio')], 404);
+        }
+
+        $email = sanitize_email($params['email'] ?? '');
+        if ( ! $email ) {
+            return new WP_REST_Response(['message' => __('A valid email is required.', 'amplisio-aio')], 400);
+        }
+
+        $preview = $this->render_template($sequence, [
+            'first_name' => __('Tester', 'amplisio-aio'),
+            'cart_link'  => esc_url(add_query_arg([], wc_get_cart_url())),
+            'coupon'     => __('SAVE10', 'amplisio-aio'),
+        ]);
+
+        $headers = apply_filters('amplisio_aio_abandoned_cart_email_headers', ['Content-Type: text/html; charset=UTF-8']);
+        wp_mail($email, $preview['subject'], $preview['body'], $headers);
+
+        return new WP_REST_Response(['sent' => true]);
+    }
+
+    private function parse_json_body(WP_REST_Request $request): array
+    {
+        $params = json_decode($request->get_body(), true);
+        if ( ! is_array($params) ) {
+            $params = [];
+        }
+
+        return $params;
+    }
+
+    private function find_sequence(array $params): ?array
+    {
+        $settings = $this->repository->get_settings();
+        $id       = sanitize_text_field((string) ($params['sequenceId'] ?? ''));
+
+        foreach ($settings['sequences'] as $sequence) {
+            if ($sequence['id'] === $id) {
+                return $sequence;
+            }
+        }
+
+        return null;
+    }
+
+    private function render_template(array $sequence, array $replacements): array
+    {
+        $map = [];
+        foreach ($replacements as $key => $value) {
+            $map['{{' . $key . '}}'] = (string) $value;
+        }
+
+        $subject = strtr($sequence['subject'], $map);
+        $body    = strtr($sequence['body'], $map);
+
+        return [
+            'subject' => $subject,
+            'body'    => wp_kses_post($body),
+        ];
+    }
+}

--- a/src/Modules/AbandonedCart/AbandonedCartSequenceRepository.php
+++ b/src/Modules/AbandonedCart/AbandonedCartSequenceRepository.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Amplisio\AIO\Modules\AbandonedCart;
+
+use function __;
+
+class AbandonedCartSequenceRepository
+{
+    private const OPTION_KEY = 'amplisio_aio_abandoned_sequences';
+
+    public function get_settings(): array
+    {
+        $stored = get_option(self::OPTION_KEY, []);
+        if ( ! is_array($stored) ) {
+            $stored = [];
+        }
+
+        return wp_parse_args($stored, $this->get_default_settings());
+    }
+
+    public function update_settings(array $settings): void
+    {
+        $defaults = $this->get_default_settings();
+        $payload  = [
+            'abandonAfterMinutes' => max(5, (int) ($settings['abandonAfterMinutes'] ?? $defaults['abandonAfterMinutes'])),
+            'expireAfterDays'     => max(1, (int) ($settings['expireAfterDays'] ?? $defaults['expireAfterDays'])),
+            'sequences'           => $this->sanitize_sequences($settings['sequences'] ?? $defaults['sequences']),
+        ];
+
+        update_option(self::OPTION_KEY, $payload, false);
+    }
+
+    public function get_sequences(): array
+    {
+        $settings = $this->get_settings();
+        return $settings['sequences'];
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'abandonAfterMinutes' => 60,
+            'expireAfterDays'     => 14,
+            'sequences'           => [
+                [
+                    'id'           => 'reminder-1',
+                    'name'         => __('First reminder', 'amplisio-aio'),
+                    'delay'        => 60,
+                    'subject'      => __('You left something behind', 'amplisio-aio'),
+                    'body'         => __('Hi {{first_name}}, we saved your cart. Complete your purchase here: {{cart_link}}', 'amplisio-aio'),
+                    'autoCoupon'   => false,
+                    'couponType'   => 'percent',
+                    'couponAmount' => 10,
+                    'couponExpiryDays' => 7,
+                ],
+                [
+                    'id'           => 'reminder-2',
+                    'name'         => __('Last chance', 'amplisio-aio'),
+                    'delay'        => 180,
+                    'subject'      => __('Still thinking it over?', 'amplisio-aio'),
+                    'body'         => __('Take another look at your cart: {{cart_link}}. Use coupon {{coupon}} before it expires.', 'amplisio-aio'),
+                    'autoCoupon'   => true,
+                    'couponType'   => 'percent',
+                    'couponAmount' => 15,
+                    'couponExpiryDays' => 3,
+                ],
+            ],
+        ];
+    }
+
+    private function sanitize_sequences(array $sequences): array
+    {
+        $sanitized = [];
+
+        foreach ($sequences as $sequence) {
+            if (empty($sequence['id'])) {
+                continue;
+            }
+
+            $sanitized[] = [
+                'id'              => sanitize_key($sequence['id']),
+                'name'            => sanitize_text_field($sequence['name'] ?? ''),
+                'delay'           => max(5, (int) ($sequence['delay'] ?? 60)),
+                'subject'         => sanitize_text_field($sequence['subject'] ?? ''),
+                'body'            => wp_kses_post($sequence['body'] ?? ''),
+                'autoCoupon'      => (bool) ($sequence['autoCoupon'] ?? false),
+                'couponType'      => in_array($sequence['couponType'] ?? 'percent', ['percent', 'fixed_cart', 'fixed_product'], true)
+                    ? $sequence['couponType']
+                    : 'percent',
+                'couponAmount'    => (float) ($sequence['couponAmount'] ?? 0),
+                'couponExpiryDays'=> max(1, (int) ($sequence['couponExpiryDays'] ?? 7)),
+            ];
+        }
+
+        return $sanitized;
+    }
+}

--- a/src/Modules/AbandonedCart/AbandonedCartService.php
+++ b/src/Modules/AbandonedCart/AbandonedCartService.php
@@ -1,0 +1,620 @@
+<?php
+
+namespace Amplisio\AIO\Modules\AbandonedCart;
+
+use DateInterval;
+use DateTimeImmutable;
+use RuntimeException;
+use wpdb;
+
+class AbandonedCartService
+{
+    private string $table;
+
+    public function __construct(private wpdb $wpdb)
+    {
+        $this->table = $wpdb->prefix . 'amplisio_carts';
+    }
+
+    public function get_table_name(): string
+    {
+        return $this->table;
+    }
+
+    public function maybe_create_table(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $this->wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$this->table} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            cart_key varchar(64) NOT NULL,
+            email varchar(190) NULL,
+            email_hash char(64) NULL,
+            first_name varchar(190) NULL,
+            status varchar(20) NOT NULL DEFAULT 'active',
+            subtotal decimal(18,6) NOT NULL DEFAULT 0,
+            items longtext NOT NULL,
+            created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
+            abandoned_at datetime NULL,
+            recovered_order_id bigint(20) unsigned NULL,
+            recovered_total decimal(18,6) NOT NULL DEFAULT 0,
+            recovered_at datetime NULL,
+            expires_at datetime NULL,
+            consent tinyint(1) NOT NULL DEFAULT 0,
+            restore_token char(64) NOT NULL,
+            coupon_code varchar(40) NULL,
+            coupon_expires_at datetime NULL,
+            sequence_log longtext NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY cart_key (cart_key),
+            KEY status (status),
+            KEY updated_at (updated_at),
+            KEY email (email(64))
+        ) $charset;";
+
+        dbDelta($sql);
+    }
+
+    /**
+     * @param array{
+     *     email?: string|null,
+     *     consent?: bool,
+     *     first_name?: string|null,
+     *     items?: array<int, array<string, mixed>>,
+     *     subtotal?: float,
+     *     expires_at?: string|null
+     * } $data
+     */
+    public function record_cart(string $cart_key, array $data): void
+    {
+        $now      = current_time('mysql', true);
+        $items    = $this->prepare_items($data['items'] ?? []);
+        $subtotal = isset($data['subtotal']) ? (float) $data['subtotal'] : 0.0;
+        $email    = isset($data['email']) ? sanitize_email((string) $data['email']) : '';
+        $first    = isset($data['first_name']) ? sanitize_text_field((string) $data['first_name']) : '';
+        $consent  = (bool) ($data['consent'] ?? false);
+        $expires  = $data['expires_at'] ?? null;
+
+        $stored_email = $consent ? $email : null;
+        $email_hash   = $email ? $this->hash_email($email) : null;
+
+        $existing = $this->get_cart_by_key($cart_key);
+
+        $payload = [
+            'email'         => $stored_email,
+            'email_hash'    => $email_hash,
+            'first_name'    => $first,
+            'items'         => $items,
+            'subtotal'      => $subtotal,
+            'updated_at'    => $now,
+            'expires_at'    => $expires ? gmdate('Y-m-d H:i:s', strtotime($expires)) : null,
+            'consent'       => $consent ? 1 : 0,
+        ];
+
+        if (null === $existing) {
+            $insert_payload = array_merge(
+                [
+                    'cart_key'      => $cart_key,
+                    'status'        => 'active',
+                    'created_at'    => $now,
+                    'restore_token' => wp_generate_password(32, false),
+                    'sequence_log'  => wp_json_encode([]),
+                ],
+                $payload
+            );
+
+            $this->wpdb->insert(
+                $this->table,
+                $insert_payload,
+                $this->formats_for($insert_payload)
+            );
+
+            return;
+        }
+
+        $status = $existing['status'];
+        if ('abandoned' === $status || 'expired' === $status) {
+            $payload['status']       = 'active';
+            $payload['abandoned_at'] = null;
+        }
+
+        $this->wpdb->update(
+            $this->table,
+            $payload,
+            ['id' => $existing['id']],
+            $this->formats_for($payload),
+            ['%d']
+        );
+    }
+
+    public function get_cart_by_key(string $cart_key): ?array
+    {
+        $row = $this->wpdb->get_row(
+            $this->wpdb->prepare("SELECT * FROM {$this->table} WHERE cart_key = %s", $cart_key),
+            ARRAY_A
+        );
+
+        return $row ?: null;
+    }
+
+    public function get_cart(int $id): ?array
+    {
+        $row = $this->wpdb->get_row(
+            $this->wpdb->prepare("SELECT * FROM {$this->table} WHERE id = %d", $id),
+            ARRAY_A
+        );
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param callable|null $scheduler Receives the cart row array when a cart becomes abandoned.
+     */
+    public function mark_carts_abandoned(int $threshold_minutes, ?callable $scheduler = null): void
+    {
+        $cutoff = gmdate('Y-m-d H:i:s', time() - ($threshold_minutes * MINUTE_IN_SECONDS));
+        $rows   = $this->wpdb->get_results(
+            $this->wpdb->prepare("SELECT * FROM {$this->table} WHERE status = 'active' AND updated_at <= %s", $cutoff),
+            ARRAY_A
+        );
+
+        foreach ($rows as $row) {
+            $abandoned_at = current_time('mysql', true);
+            $this->wpdb->update(
+                $this->table,
+                [
+                    'status'       => 'abandoned',
+                    'abandoned_at' => $abandoned_at,
+                    'updated_at'   => $abandoned_at,
+                ],
+                ['id' => $row['id']],
+                ['%s', '%s', '%s'],
+                ['%d']
+            );
+
+            if (null !== $scheduler) {
+                $row['abandoned_at'] = $abandoned_at;
+                $scheduler($row);
+            }
+        }
+    }
+
+    public function mark_recovered(int $cart_id, int $order_id, float $total, string $email, string $first_name = ''): void
+    {
+        $now   = current_time('mysql', true);
+        $email = sanitize_email($email);
+        $first = sanitize_text_field($first_name);
+
+        $this->wpdb->update(
+            $this->table,
+            [
+                'status'            => 'recovered',
+                'recovered_order_id'=> $order_id,
+                'recovered_total'   => $total,
+                'recovered_at'      => $now,
+                'updated_at'        => $now,
+                'email'             => $email,
+                'email_hash'        => $email ? $this->hash_email($email) : null,
+                'first_name'        => $first,
+                'consent'           => 1,
+            ],
+            ['id' => $cart_id],
+            ['%s', '%d', '%f', '%s', '%s', '%s', '%s', '%s', '%d'],
+            ['%d']
+        );
+
+        $this->add_sequence_recovery_marker($cart_id);
+    }
+
+    public function expire_abandoned_carts(int $days): void
+    {
+        $cutoff = gmdate('Y-m-d H:i:s', time() - ($days * DAY_IN_SECONDS));
+        $this->wpdb->query(
+            $this->wpdb->prepare(
+                "UPDATE {$this->table} SET status = 'expired', updated_at = %s WHERE status = 'abandoned' AND abandoned_at <= %s",
+                current_time('mysql', true),
+                $cutoff
+            )
+        );
+    }
+
+    public function issue_coupon_for_cart(int $cart_id, string $email, array $config): ?array
+    {
+        $cart = $this->get_cart($cart_id);
+        if ( ! $cart ) {
+            throw new RuntimeException('Cart not found.');
+        }
+
+        if ( ! empty($cart['coupon_code']) ) {
+            return [
+                'code'       => $cart['coupon_code'],
+                'expires_at' => $cart['coupon_expires_at'],
+            ];
+        }
+
+        $email = sanitize_email($email);
+        if ( ! $email ) {
+            return null;
+        }
+
+        $coupon = apply_filters('amplisio_aio_generate_coupon', null, $cart_id, $email, $config);
+        if ( is_array($coupon) && ! empty($coupon['code']) ) {
+            $this->store_coupon($cart_id, $coupon['code'], $coupon['expires_at'] ?? null);
+            return [
+                'code'       => $coupon['code'],
+                'expires_at' => $coupon['expires_at'] ?? null,
+            ];
+        }
+
+        if ( class_exists('WC_Coupon') ) {
+            $code   = strtolower(wp_generate_password(10, false));
+            $coupon = new \WC_Coupon();
+            $coupon->set_code($code);
+            $coupon->set_amount((float) ($config['couponAmount'] ?? 0));
+            $coupon->set_discount_type($config['couponType'] ?? 'percent');
+            $coupon->set_email_restrictions([$email]);
+
+            if ( ! empty($config['couponExpiryDays']) ) {
+                $date = (new DateTimeImmutable('now', wp_timezone()))->add(new DateInterval('P' . (int) $config['couponExpiryDays'] . 'D'));
+                $coupon->set_date_expires($date);
+                $expires = $date->format('Y-m-d H:i:s');
+            } else {
+                $expires = null;
+            }
+
+            $coupon->save();
+
+            $this->store_coupon($cart_id, $code, $expires);
+
+            return [
+                'code'       => $code,
+                'expires_at' => $expires,
+            ];
+        }
+
+        return null;
+    }
+
+    public function log_sequence_event(int $cart_id, array $event): void
+    {
+        $cart = $this->get_cart($cart_id);
+        if ( ! $cart ) {
+            return;
+        }
+
+        $log = [];
+        if ( ! empty($cart['sequence_log']) ) {
+            $decoded = json_decode((string) $cart['sequence_log'], true);
+            if ( is_array($decoded) ) {
+                $log = $decoded;
+            }
+        }
+
+        $event['timestamp'] = current_time('mysql', true);
+        $log[]              = $event;
+
+        $data = [
+            'sequence_log' => wp_json_encode($log),
+            'updated_at'   => current_time('mysql', true),
+        ];
+
+        $this->wpdb->update(
+            $this->table,
+            $data,
+            ['id' => $cart_id],
+            $this->formats_for($data),
+            ['%d']
+        );
+    }
+
+    public function get_stats(): array
+    {
+        $totals = $this->wpdb->get_results("SELECT status, COUNT(*) AS total FROM {$this->table} GROUP BY status", ARRAY_A);
+        $counts = [
+            'active'    => 0,
+            'abandoned' => 0,
+            'recovered' => 0,
+            'expired'   => 0,
+        ];
+
+        foreach ($totals as $row) {
+            $counts[$row['status']] = (int) $row['total'];
+        }
+
+        $recovered_amount = (float) $this->wpdb->get_var("SELECT SUM(recovered_total) FROM {$this->table} WHERE status = 'recovered'");
+
+        return [
+            'counts'   => $counts,
+            'revenue'  => $recovered_amount,
+        ];
+    }
+
+    public function get_recent_recoveries(int $limit = 10): array
+    {
+        return $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT recovered_order_id, recovered_total, recovered_at, email FROM {$this->table} WHERE status = 'recovered' ORDER BY recovered_at DESC LIMIT %d",
+                $limit
+            ),
+            ARRAY_A
+        );
+    }
+
+    public function get_top_products(int $limit = 5): array
+    {
+        $rows = $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT items FROM {$this->table} WHERE status = 'recovered' ORDER BY recovered_at DESC LIMIT %d",
+                $limit * 5
+            ),
+            ARRAY_A
+        );
+
+        $products = [];
+
+        foreach ($rows as $row) {
+            $items = json_decode((string) $row['items'], true);
+            if ( ! is_array($items) ) {
+                continue;
+            }
+
+            foreach ($items as $item) {
+                if ( empty($item['product_id']) ) {
+                    continue;
+                }
+
+                $id = (int) $item['product_id'];
+                if ( ! isset($products[$id]) ) {
+                    $products[$id] = [
+                        'product_id' => $id,
+                        'name'       => sanitize_text_field($item['name'] ?? ''),
+                        'quantity'   => 0,
+                    ];
+                }
+
+                $products[$id]['quantity'] += (int) ($item['quantity'] ?? 0);
+            }
+        }
+
+        usort($products, static fn ($a, $b) => $b['quantity'] <=> $a['quantity']);
+
+        return array_slice(array_values($products), 0, $limit);
+    }
+
+    public function get_sequence_performance(array $sequences): array
+    {
+        $stats = [];
+        foreach ($sequences as $sequence) {
+            $stats[$sequence['id']] = [
+                'id'        => $sequence['id'],
+                'name'      => $sequence['name'] ?? $sequence['id'],
+                'sent'      => 0,
+                'recovered' => 0,
+            ];
+        }
+
+        $rows = $this->wpdb->get_results("SELECT sequence_log FROM {$this->table} WHERE sequence_log IS NOT NULL", ARRAY_A);
+        foreach ($rows as $row) {
+            $events = json_decode((string) $row['sequence_log'], true);
+            if ( ! is_array($events) ) {
+                continue;
+            }
+
+            foreach ($events as $event) {
+                if ( empty($event['sequence_id']) || empty($stats[$event['sequence_id']]) ) {
+                    continue;
+                }
+
+                if ( ('sent' === ($event['type'] ?? '')) ) {
+                    $stats[$event['sequence_id']]['sent']++;
+                }
+
+                if ( ('recovered' === ($event['type'] ?? '')) ) {
+                    $stats[$event['sequence_id']]['recovered']++;
+                }
+            }
+        }
+
+        return array_values($stats);
+    }
+
+    public function add_sequence_recovery_marker(int $cart_id): void
+    {
+        $cart = $this->get_cart($cart_id);
+        if ( ! $cart ) {
+            return;
+        }
+
+        $log = [];
+        if ( ! empty($cart['sequence_log']) ) {
+            $decoded = json_decode((string) $cart['sequence_log'], true);
+            if ( is_array($decoded) ) {
+                $log = $decoded;
+            }
+        }
+
+        $last_sequence = null;
+        for ($i = count($log) - 1; $i >= 0; $i--) {
+            if (('sent' === ($log[$i]['type'] ?? '')) && ! empty($log[$i]['sequence_id'])) {
+                $last_sequence = $log[$i]['sequence_id'];
+                break;
+            }
+        }
+
+        if (null === $last_sequence) {
+            return;
+        }
+
+        $log[] = [
+            'type'        => 'recovered',
+            'sequence_id' => $last_sequence,
+            'timestamp'   => current_time('mysql', true),
+        ];
+
+        $data = [
+            'sequence_log' => wp_json_encode($log),
+            'updated_at'   => current_time('mysql', true),
+        ];
+
+        $this->wpdb->update(
+            $this->table,
+            $data,
+            ['id' => $cart_id],
+            $this->formats_for($data),
+            ['%d']
+        );
+    }
+
+    public function get_restore_payload(string $cart_key, string $token): ?array
+    {
+        $row = $this->wpdb->get_row(
+            $this->wpdb->prepare(
+                "SELECT * FROM {$this->table} WHERE cart_key = %s AND restore_token = %s",
+                $cart_key,
+                $token
+            ),
+            ARRAY_A
+        );
+
+        if ( ! $row ) {
+            return null;
+        }
+
+        $items = json_decode((string) $row['items'], true);
+        if ( ! is_array($items) ) {
+            $items = [];
+        }
+
+        return [
+            'items'       => $items,
+            'coupon_code' => $row['coupon_code'] ?? null,
+        ];
+    }
+
+    public function set_consent(int $cart_id, string $email, ?string $first_name = null): void
+    {
+        $email = sanitize_email($email);
+        $data  = [
+            'email'      => $email,
+            'email_hash' => $email ? $this->hash_email($email) : null,
+            'consent'    => $email ? 1 : 0,
+        ];
+
+        if (null !== $first_name) {
+            $data['first_name'] = sanitize_text_field($first_name);
+        }
+
+        $this->wpdb->update(
+            $this->table,
+            $data,
+            ['id' => $cart_id],
+            $this->formats_for($data),
+            ['%d']
+        );
+    }
+
+    public function find_carts_for_email(string $email): array
+    {
+        $email = sanitize_email($email);
+        if ( ! $email ) {
+            return [];
+        }
+
+        $hash = $this->hash_email($email);
+
+        return $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT * FROM {$this->table} WHERE email = %s OR email_hash = %s ORDER BY updated_at DESC",
+                $email,
+                $hash
+            ),
+            ARRAY_A
+        );
+    }
+
+    public function erase_carts_for_email(string $email): int
+    {
+        $email = sanitize_email($email);
+        if ( ! $email ) {
+            return 0;
+        }
+
+        $hash = $this->hash_email($email);
+
+        return (int) $this->wpdb->query(
+            $this->wpdb->prepare(
+                "DELETE FROM {$this->table} WHERE email = %s OR email_hash = %s",
+                $email,
+                $hash
+            )
+        );
+    }
+
+    private function store_coupon(int $cart_id, string $code, ?string $expires): void
+    {
+        $data = [
+            'coupon_code'       => sanitize_text_field($code),
+            'coupon_expires_at' => $expires ? gmdate('Y-m-d H:i:s', strtotime($expires)) : null,
+            'updated_at'        => current_time('mysql', true),
+        ];
+
+        $this->wpdb->update(
+            $this->table,
+            $data,
+            ['id' => $cart_id],
+            $this->formats_for($data),
+            ['%d']
+        );
+    }
+
+    private function prepare_items(array $items): string
+    {
+        $normalized = [];
+        foreach ($items as $item) {
+            $normalized[] = [
+                'product_id'   => isset($item['product_id']) ? (int) $item['product_id'] : 0,
+                'variation_id' => isset($item['variation_id']) ? (int) $item['variation_id'] : 0,
+                'quantity'     => isset($item['quantity']) ? (int) $item['quantity'] : 0,
+                'name'         => sanitize_text_field($item['name'] ?? ''),
+            ];
+        }
+
+        return wp_json_encode($normalized);
+    }
+
+    private function hash_email(string $email): string
+    {
+        return hash_hmac('sha256', strtolower($email), wp_salt('amplisio_aio'));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<int, string>
+     */
+    private function formats_for(array $data): array
+    {
+        $map = [];
+
+        foreach ($data as $key => $value) {
+            switch ($key) {
+                case 'subtotal':
+                case 'recovered_total':
+                    $map[] = '%f';
+                    break;
+                case 'recovered_order_id':
+                    $map[] = '%d';
+                    break;
+                case 'consent':
+                    $map[] = '%d';
+                    break;
+                default:
+                    $map[] = '%s';
+            }
+        }
+
+        return $map;
+    }
+}

--- a/src/Modules/AbstractModule.php
+++ b/src/Modules/AbstractModule.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Amplisio\AIO\Modules;
+
+use Amplisio\AIO\Services\Container;
+
+use function wp_parse_args;
+
+abstract class AbstractModule implements ModuleInterface
+{
+    public function register(Container $container): void
+    {
+        // Default no-op.
+    }
+
+    public function boot(Container $container): void
+    {
+        // Default no-op.
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        return [];
+    }
+
+    public function get_capability(): string
+    {
+        return 'manage_woocommerce';
+    }
+
+    public function sanitize_settings(array $settings): array
+    {
+        $defaults   = $this->get_default_settings();
+        $sanitized  = wp_parse_args($settings, $defaults);
+
+        if (array_key_exists('enabled', $defaults)) {
+            $sanitized['enabled'] = (bool) $sanitized['enabled'];
+        }
+
+        return $sanitized;
+    }
+
+    public function get_rest_base(): string
+    {
+        return $this->get_id();
+    }
+
+    public function run_scheduled_event(): void
+    {
+        // Default no-op.
+    }
+}

--- a/src/Modules/Analytics/AnalyticsModule.php
+++ b/src/Modules/Analytics/AnalyticsModule.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Amplisio\AIO\Modules\Analytics;
+
+use Amplisio\AIO\Modules\AbstractModule;
+use Amplisio\AIO\Services\Container;
+
+class AnalyticsModule extends AbstractModule
+{
+    private ?AnalyticsService $service = null;
+
+    public function get_id(): string
+    {
+        return 'analytics';
+    }
+
+    public function get_name(): string
+    {
+        return __('Intelligence', 'amplisio-aio');
+    }
+
+    public function register(Container $container): void
+    {
+        $container->singleton(AnalyticsService::class, static fn (): AnalyticsService => new AnalyticsService());
+        $this->service = $container->get(AnalyticsService::class);
+    }
+
+    public function boot(Container $container): void
+    {
+        $service = $this->service ?? $container->get(AnalyticsService::class);
+
+        add_action('rest_api_init', static function () use ($service): void {
+            (new AnalyticsRestController($service))->register_routes();
+        });
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'enabled' => true,
+        ];
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        $service = $this->service ?? new AnalyticsService();
+        $metrics = $service->get_dashboard_metrics();
+
+        return [
+            [
+                'id'          => 'aov',
+                'title'       => __('Average order value', 'amplisio-aio'),
+                'value'       => $metrics['average_order_value'],
+                'description' => __('Rolling 30 day AOV', 'amplisio-aio'),
+            ],
+            [
+                'id'          => 'conversion',
+                'title'       => __('Conversion rate', 'amplisio-aio'),
+                'value'       => $metrics['conversion_rate'],
+                'description' => __('Orders / checkouts in last 30 days', 'amplisio-aio'),
+            ],
+            [
+                'id'          => 'ltv',
+                'title'       => __('Customer lifetime value', 'amplisio-aio'),
+                'value'       => $metrics['customer_lifetime_value'],
+                'description' => __('Median spend per customer', 'amplisio-aio'),
+            ],
+        ];
+    }
+
+    public function run_scheduled_event(): void
+    {
+        ($this->service ?? new AnalyticsService())->prime_cache();
+    }
+}

--- a/src/Modules/Analytics/AnalyticsRestController.php
+++ b/src/Modules/Analytics/AnalyticsRestController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Amplisio\AIO\Modules\Analytics;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Response;
+
+class AnalyticsRestController extends WP_REST_Controller
+{
+    public function __construct(private AnalyticsService $service)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'analytics';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to view Amplisio analytics.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_items(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->service->get_dashboard_metrics());
+    }
+}

--- a/src/Modules/Analytics/AnalyticsService.php
+++ b/src/Modules/Analytics/AnalyticsService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Amplisio\AIO\Modules\Analytics;
+
+use WC_Order;
+use WC_Order_Query;
+
+class AnalyticsService
+{
+    private const CACHE_KEY = 'amplisio_aio_analytics_metrics';
+    private const CACHE_TTL = 15 * MINUTE_IN_SECONDS;
+
+    public function get_dashboard_metrics(): array
+    {
+        $cached = get_transient(self::CACHE_KEY);
+        if ( $cached && is_array($cached) ) {
+            return $cached;
+        }
+
+        $metrics = $this->calculate_metrics();
+        set_transient(self::CACHE_KEY, $metrics, self::CACHE_TTL);
+
+        return $metrics;
+    }
+
+    public function prime_cache(): void
+    {
+        $metrics = $this->calculate_metrics();
+        set_transient(self::CACHE_KEY, $metrics, self::CACHE_TTL);
+    }
+
+    private function calculate_metrics(): array
+    {
+        $orders = $this->get_recent_orders();
+
+        $total_value = 0.0;
+        $order_count = count($orders);
+        $customers   = [];
+
+        foreach ($orders as $order) {
+            $total_value += (float) $order->get_total();
+            $customers[$order->get_customer_id() ?: $order->get_billing_email()][] = (float) $order->get_total();
+        }
+
+        $average_order_value = $order_count > 0 ? $total_value / $order_count : 0.0;
+        $ltv_values          = array_map(
+            static fn (array $purchases): float => array_sum($purchases),
+            $customers
+        );
+
+        $median_ltv = 0.0;
+        if ( ! empty($ltv_values) ) {
+            sort($ltv_values);
+            $middle = (int) floor((count($ltv_values) - 1) / 2);
+            if ( count($ltv_values) % 2 ) {
+                $median_ltv = $ltv_values[$middle];
+            } else {
+                $median_ltv = ($ltv_values[$middle] + $ltv_values[$middle + 1]) / 2;
+            }
+        }
+
+        $checkout_sessions = max($order_count, (int) get_option('amplisio_aio_checkout_sessions', $order_count));
+        $conversion_rate   = $checkout_sessions > 0 ? ($order_count / $checkout_sessions) * 100 : 0.0;
+
+        return [
+            'average_order_value'     => wc_price($average_order_value),
+            'conversion_rate'         => number_format_i18n($conversion_rate, 2) . '%',
+            'customer_lifetime_value' => wc_price($median_ltv),
+        ];
+    }
+
+    /**
+     * @return WC_Order[]
+     */
+    private function get_recent_orders(): array
+    {
+        $query = new WC_Order_Query([
+            'status' => ['wc-completed', 'wc-processing'],
+            'date_created' => '>' . (new \DateTime('-30 days'))->format('Y-m-d H:i:s'),
+            'limit' => 100,
+            'type' => 'shop_order',
+            'return' => 'objects',
+        ]);
+
+        return $query->get_orders();
+    }
+}

--- a/src/Modules/BackInStock/BackInStockModule.php
+++ b/src/Modules/BackInStock/BackInStockModule.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Amplisio\AIO\Modules\BackInStock;
+
+use Amplisio\AIO\Modules\AbstractModule;
+use Amplisio\AIO\Services\Container;
+
+class BackInStockModule extends AbstractModule
+{
+    private ?BackInStockService $service = null;
+
+    public function get_id(): string
+    {
+        return 'back_in_stock';
+    }
+
+    public function get_name(): string
+    {
+        return __('Back in stock', 'amplisio-aio');
+    }
+
+    public function get_rest_base(): string
+    {
+        return 'back-in-stock';
+    }
+
+    public function register(Container $container): void
+    {
+        $container->singleton(BackInStockService::class, static fn (): BackInStockService => new BackInStockService($GLOBALS['wpdb']));
+        $this->service = $container->get(BackInStockService::class);
+    }
+
+    public function boot(Container $container): void
+    {
+        $service = $this->service ?? $container->get(BackInStockService::class);
+        $service->maybe_create_table();
+
+        add_action('rest_api_init', static function () use ($service): void {
+            (new BackInStockRestController($service))->register_routes();
+        });
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'enabled' => false,
+        ];
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        $summary = ($this->service ?? new BackInStockService($GLOBALS['wpdb']))->get_summary();
+
+        return [
+            [
+                'id'          => 'back-in-stock-total',
+                'title'       => __('Back-in-stock signups', 'amplisio-aio'),
+                'value'       => number_format_i18n($summary['total']),
+                'description' => __('All-time subscribers', 'amplisio-aio'),
+            ],
+            [
+                'id'          => 'back-in-stock-pending',
+                'title'       => __('Waiting to notify', 'amplisio-aio'),
+                'value'       => number_format_i18n($summary['pending']),
+                'description' => __('Customers to alert when inventory returns', 'amplisio-aio'),
+            ],
+        ];
+    }
+
+    public function run_scheduled_event(): void
+    {
+        ($this->service ?? new BackInStockService($GLOBALS['wpdb']))->cleanup();
+    }
+}

--- a/src/Modules/BackInStock/BackInStockRestController.php
+++ b/src/Modules/BackInStock/BackInStockRestController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Amplisio\AIO\Modules\BackInStock;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class BackInStockRestController extends WP_REST_Controller
+{
+    public function __construct(private BackInStockService $service)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'back-in-stock';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'view_permissions_check'],
+                ],
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'create_item'],
+                    'permission_callback' => '__return_true',
+                ],
+            ]
+        );
+    }
+
+    public function view_permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to view signups.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_items(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->service->get_summary());
+    }
+
+    public function create_item(WP_REST_Request $request): WP_REST_Response
+    {
+        $nonce = $request->get_header('X-WP-Nonce');
+        if ( ! wp_verify_nonce($nonce, 'wp_rest') ) {
+            return new WP_REST_Response(['message' => __('Invalid security token.', 'amplisio-aio')], 403);
+        }
+
+        $product_id = (int) $request->get_param('product_id');
+        $email      = sanitize_email((string) $request->get_param('email'));
+
+        if ( $product_id <= 0 || empty($email) ) {
+            return new WP_REST_Response(['message' => __('Missing signup data.', 'amplisio-aio')], 400);
+        }
+
+        $this->service->record_signup($product_id, $email);
+
+        return new WP_REST_Response(['message' => __('Signup saved.', 'amplisio-aio')]);
+    }
+}

--- a/src/Modules/BackInStock/BackInStockService.php
+++ b/src/Modules/BackInStock/BackInStockService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Amplisio\AIO\Modules\BackInStock;
+
+use wpdb;
+
+class BackInStockService
+{
+    private string $table;
+
+    public function __construct(private wpdb $wpdb)
+    {
+        $this->table = $wpdb->prefix . 'amplisio_back_in_stock';
+    }
+
+    public function maybe_create_table(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $this->wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$this->table} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            product_id bigint(20) unsigned NOT NULL,
+            email varchar(190) NOT NULL,
+            created_at datetime NOT NULL,
+            notified_at datetime NULL,
+            PRIMARY KEY (id),
+            KEY product_id (product_id),
+            KEY notified_at (notified_at)
+        ) $charset;";
+
+        dbDelta($sql);
+    }
+
+    public function record_signup(int $product_id, string $email): void
+    {
+        $this->wpdb->insert(
+            $this->table,
+            [
+                'product_id' => $product_id,
+                'email'      => sanitize_email($email),
+                'created_at' => current_time('mysql'),
+            ],
+            ['%d', '%s', '%s']
+        );
+    }
+
+    public function get_summary(): array
+    {
+        $total = (int) $this->wpdb->get_var("SELECT COUNT(id) FROM {$this->table}");
+        $pending = (int) $this->wpdb->get_var("SELECT COUNT(id) FROM {$this->table} WHERE notified_at IS NULL");
+
+        return [
+            'total'   => $total,
+            'pending' => $pending,
+        ];
+    }
+
+    public function cleanup(): void
+    {
+        $threshold = gmdate('Y-m-d H:i:s', strtotime('-365 days'));
+        $this->wpdb->query(
+            $this->wpdb->prepare("DELETE FROM {$this->table} WHERE created_at < %s", $threshold)
+        );
+    }
+}

--- a/src/Modules/ModuleInterface.php
+++ b/src/Modules/ModuleInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Amplisio\AIO\Modules;
+
+use Amplisio\AIO\Services\Container;
+
+interface ModuleInterface
+{
+    public function get_id(): string;
+
+    public function get_name(): string;
+
+    public function register(Container $container): void;
+
+    public function boot(Container $container): void;
+
+    public function get_default_settings(): array;
+
+    public function get_dashboard_cards(): array;
+
+    public function get_capability(): string;
+
+    public function sanitize_settings(array $settings): array;
+
+    public function get_rest_base(): string;
+
+    public function run_scheduled_event(): void;
+}

--- a/src/Modules/ModuleManager.php
+++ b/src/Modules/ModuleManager.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Amplisio\AIO\Modules;
+
+use Amplisio\AIO\Repositories\OptionRepository;
+use Amplisio\AIO\Services\Container;
+
+class ModuleManager
+{
+    /**
+     * @var array<string, ModuleInterface>
+     */
+    private array $modules = [];
+
+    public function __construct(private OptionRepository $options, private Container $container)
+    {
+    }
+
+    public function register_module(ModuleInterface $module): void
+    {
+        $this->modules[$module->get_id()] = $module;
+        $module->register($this->container);
+
+        $stored = $this->options->get_modules()[$module->get_id()] ?? [];
+
+        if (is_bool($stored)) {
+            $stored = ['enabled' => $stored];
+        } elseif ( ! is_array($stored) ) {
+            $stored = [];
+        }
+
+        $sanitized = $module->sanitize_settings($stored);
+        $this->options->set_module_settings($module->get_id(), $sanitized);
+    }
+
+    public function boot_enabled_modules(): void
+    {
+        foreach ($this->modules as $module) {
+            if ( $this->options->is_module_enabled($module->get_id()) ) {
+                $module->boot($this->container);
+            }
+        }
+    }
+
+    public function get_modules(): array
+    {
+        return $this->modules;
+    }
+
+    public function get_module(string $module_id): ?ModuleInterface
+    {
+        return $this->modules[$module_id] ?? null;
+    }
+
+    public function enabled_modules(): array
+    {
+        return array_filter(
+            $this->modules,
+            fn (ModuleInterface $module): bool => $this->options->is_module_enabled($module->get_id())
+        );
+    }
+
+    public function set_module_status(string $module_id, bool $enabled): void
+    {
+        if ( ! isset($this->modules[$module_id]) ) {
+            return;
+        }
+
+        $settings             = $this->get_module_settings($module_id);
+        $settings['enabled']  = $enabled;
+
+        $this->update_module_settings($module_id, $settings);
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        $cards = [];
+        foreach ($this->enabled_modules() as $module) {
+            $cards = array_merge($cards, $module->get_dashboard_cards());
+        }
+
+        return $cards;
+    }
+
+    public function run_scheduled_events(): void
+    {
+        foreach ($this->enabled_modules() as $module) {
+            $module->run_scheduled_event();
+        }
+    }
+
+    public function get_module_settings(string $module_id): array
+    {
+        if ( ! isset($this->modules[$module_id]) ) {
+            return [];
+        }
+
+        $stored = $this->options->get_modules()[$module_id] ?? [];
+
+        if (is_bool($stored)) {
+            $stored = ['enabled' => $stored];
+        } elseif ( ! is_array($stored) ) {
+            $stored = [];
+        }
+
+        return $this->modules[$module_id]->sanitize_settings($stored);
+    }
+
+    public function update_module_settings(string $module_id, array $settings): array
+    {
+        if ( ! isset($this->modules[$module_id]) ) {
+            return [];
+        }
+
+        $current = $this->get_module_settings($module_id);
+        $merged  = array_merge($current, $settings);
+        $clean   = $this->modules[$module_id]->sanitize_settings($merged);
+
+        $this->options->set_module_settings($module_id, $clean);
+
+        return $clean;
+    }
+}

--- a/src/Modules/RecoveredCarts/RecoveredCartsModule.php
+++ b/src/Modules/RecoveredCarts/RecoveredCartsModule.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Amplisio\AIO\Modules\RecoveredCarts;
+
+use Amplisio\AIO\Modules\AbstractModule;
+use Amplisio\AIO\Services\Container;
+use WC_Order;
+
+class RecoveredCartsModule extends AbstractModule
+{
+    private ?RecoveredCartsService $service = null;
+
+    public function get_id(): string
+    {
+        return 'recovered_carts';
+    }
+
+    public function get_name(): string
+    {
+        return __('Recovered carts', 'amplisio-aio');
+    }
+
+    public function get_rest_base(): string
+    {
+        return 'recovered-carts';
+    }
+
+    public function register(Container $container): void
+    {
+        $container->singleton(RecoveredCartsService::class, static fn (): RecoveredCartsService => new RecoveredCartsService($GLOBALS['wpdb']));
+        $this->service = $container->get(RecoveredCartsService::class);
+    }
+
+    public function boot(Container $container): void
+    {
+        $service = $this->service ?? $container->get(RecoveredCartsService::class);
+        $service->maybe_create_table();
+
+        add_action('woocommerce_order_status_completed', static function (int $order_id) use ($service): void {
+            $order = wc_get_order($order_id);
+            if ( ! $order instanceof WC_Order ) {
+                return;
+            }
+
+            $flag = $order->get_meta('_amplisio_recovered_cart', true);
+            if ( 'yes' !== $flag ) {
+                return;
+            }
+
+            $service->record($order_id, (string) $order->get_billing_email(), (float) $order->get_total());
+        });
+
+        add_action('rest_api_init', static function () use ($service): void {
+            (new RecoveredCartsRestController($service))->register_routes();
+        });
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'enabled' => false,
+        ];
+    }
+
+    public function get_dashboard_cards(): array
+    {
+        $summary = ($this->service ?? new RecoveredCartsService($GLOBALS['wpdb']))->get_summary();
+
+        return [
+            [
+                'id'          => 'recovered-carts',
+                'title'       => __('Recovered carts', 'amplisio-aio'),
+                'value'       => number_format_i18n($summary['count']),
+                'description' => __('Recovered over the last 6 months', 'amplisio-aio'),
+            ],
+            [
+                'id'          => 'recovered-revenue',
+                'title'       => __('Recovered revenue', 'amplisio-aio'),
+                'value'       => wc_price($summary['amount']),
+                'description' => __('Total revenue attributed to recovery flows', 'amplisio-aio'),
+            ],
+        ];
+    }
+
+    public function run_scheduled_event(): void
+    {
+        ($this->service ?? new RecoveredCartsService($GLOBALS['wpdb']))->cleanup();
+    }
+}

--- a/src/Modules/RecoveredCarts/RecoveredCartsRestController.php
+++ b/src/Modules/RecoveredCarts/RecoveredCartsRestController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Amplisio\AIO\Modules\RecoveredCarts;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Response;
+
+class RecoveredCartsRestController extends WP_REST_Controller
+{
+    public function __construct(private RecoveredCartsService $service)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'recovered-carts';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to view recovered carts.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_items(): WP_REST_Response
+    {
+        return new WP_REST_Response($this->service->get_summary());
+    }
+}

--- a/src/Modules/RecoveredCarts/RecoveredCartsService.php
+++ b/src/Modules/RecoveredCarts/RecoveredCartsService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Amplisio\AIO\Modules\RecoveredCarts;
+
+use wpdb;
+
+class RecoveredCartsService
+{
+    private string $table;
+
+    public function __construct(private wpdb $wpdb)
+    {
+        $this->table = $wpdb->prefix . 'amplisio_recovered_carts';
+    }
+
+    public function maybe_create_table(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $this->wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$this->table} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            order_id bigint(20) unsigned NOT NULL,
+            email varchar(190) NOT NULL,
+            recovered_amount decimal(18,6) NOT NULL DEFAULT 0,
+            recovered_at datetime NOT NULL,
+            status varchar(20) NOT NULL DEFAULT 'completed',
+            PRIMARY KEY  (id),
+            KEY status (status),
+            KEY recovered_at (recovered_at)
+        ) $charset;";
+
+        dbDelta($sql);
+    }
+
+    public function record(int $order_id, string $email, float $amount): void
+    {
+        $this->wpdb->insert(
+            $this->table,
+            [
+                'order_id'        => $order_id,
+                'email'           => sanitize_email($email),
+                'recovered_amount'=> $amount,
+                'recovered_at'    => current_time('mysql'),
+                'status'          => 'completed',
+            ],
+            ['%d', '%s', '%f', '%s', '%s']
+        );
+    }
+
+    public function get_summary(): array
+    {
+        $total = (float) $this->wpdb->get_var("SELECT SUM(recovered_amount) FROM {$this->table} WHERE status = 'completed'");
+        $count = (int) $this->wpdb->get_var("SELECT COUNT(id) FROM {$this->table} WHERE status = 'completed'");
+
+        return [
+            'count'  => $count,
+            'amount' => $total,
+        ];
+    }
+
+    public function cleanup(): void
+    {
+        $threshold = gmdate('Y-m-d H:i:s', strtotime('-180 days'));
+        $this->wpdb->query(
+            $this->wpdb->prepare("DELETE FROM {$this->table} WHERE recovered_at < %s", $threshold)
+        );
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Amplisio\AIO;
+
+use Amplisio\AIO\Repositories\OptionRepository;
+use Amplisio\AIO\Services\Container;
+use Amplisio\AIO\Services\Providers\CoreServiceProvider;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+class Plugin
+{
+    private string $file;
+
+    private Container $container;
+
+    public function __construct(string $file)
+    {
+        $this->file      = $file;
+        $this->container = new Container();
+    }
+
+    public function boot(): void
+    {
+        register_activation_hook($this->file, [self::class, 'activate']);
+        register_deactivation_hook($this->file, [self::class, 'deactivate']);
+
+        add_action('before_woocommerce_init', [$this, 'declare_hpos_compatibility']);
+        add_action('plugins_loaded', [$this, 'init']);
+    }
+
+    public function init(): void
+    {
+        load_plugin_textdomain('amplisio-aio', false, dirname(plugin_basename($this->file)) . '/languages/');
+
+        $this->container->singleton(Container::class, fn (): Container => $this->container);
+        $this->container->singleton(OptionRepository::class, fn (): OptionRepository => new OptionRepository());
+
+        $core = new CoreServiceProvider($this->container, $this->file);
+        $core->register();
+        $core->boot();
+    }
+
+    public static function activate(): void
+    {
+        $repository = new OptionRepository();
+        $repository->initialize_defaults();
+    }
+
+    public static function deactivate(): void
+    {
+        // Placeholder for potential cleanup in future versions.
+    }
+
+    public function declare_hpos_compatibility(): void
+    {
+        if ( class_exists(FeaturesUtil::class) ) {
+            FeaturesUtil::declare_compatibility('custom_order_tables', plugin_basename($this->file), true);
+        }
+    }
+
+    public function container(): Container
+    {
+        return $this->container;
+    }
+}

--- a/src/Repositories/OptionRepository.php
+++ b/src/Repositories/OptionRepository.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Amplisio\AIO\Repositories;
+
+class OptionRepository
+{
+    public const OPTION_KEY = 'amplisio_aio_settings';
+
+    public function initialize_defaults(): void
+    {
+        $defaults = $this->get_defaults();
+        $existing = get_option(self::OPTION_KEY);
+
+        if ( ! is_array($existing) ) {
+            update_option(self::OPTION_KEY, $defaults, false);
+            return;
+        }
+
+        $merged = wp_parse_args($existing, $defaults);
+        if ( ! is_array($merged['modules']) ) {
+            $merged['modules'] = [];
+        }
+
+        update_option(self::OPTION_KEY, $merged, false);
+    }
+
+    public function get(): array
+    {
+        $value = get_option(self::OPTION_KEY, []);
+        if ( ! is_array($value) ) {
+            $value = [];
+        }
+
+        $value = wp_parse_args($value, $this->get_defaults());
+
+        if ( ! is_array($value['modules']) ) {
+            $value['modules'] = [];
+        }
+
+        return $value;
+    }
+
+    public function update(array $settings): void
+    {
+        $settings = wp_parse_args($settings, $this->get_defaults());
+        update_option(self::OPTION_KEY, $settings, false);
+    }
+
+    public function get_theme_settings(): array
+    {
+        $settings = $this->get();
+        return $settings['theme'];
+    }
+
+    public function get_modules(): array
+    {
+        $settings = $this->get();
+        return $settings['modules'];
+    }
+
+    public function is_module_enabled(string $module_id): bool
+    {
+        $modules = $this->get_modules();
+        $module  = $modules[$module_id] ?? false;
+
+        if (is_array($module)) {
+            return (bool) ($module['enabled'] ?? false);
+        }
+
+        return (bool) $module;
+    }
+
+    public function set_module_status(string $module_id, bool $enabled): void
+    {
+        $settings = $this->get();
+        $module   = $settings['modules'][$module_id] ?? [];
+
+        if (is_bool($module)) {
+            $module = ['enabled' => $module];
+        } elseif ( ! is_array($module) ) {
+            $module = [];
+        }
+
+        $module['enabled']           = $enabled;
+        $settings['modules'][$module_id] = $module;
+
+        $this->update($settings);
+    }
+
+    public function update_theme_settings(array $theme): void
+    {
+        $settings         = $this->get();
+        $settings['theme'] = wp_parse_args($theme, $this->get_defaults()['theme']);
+        $this->update($settings);
+    }
+
+    public function set_module_settings(string $module_id, array $module_settings): void
+    {
+        $settings                    = $this->get();
+        $settings['modules'][$module_id] = $module_settings;
+        $this->update($settings);
+    }
+
+    private function get_defaults(): array
+    {
+        return [
+            'theme'   => [
+                'fontFamily'   => '',
+                'primaryColor' => '',
+                'accentColor'  => '',
+                'radius'       => '',
+            ],
+            'modules' => [],
+        ];
+    }
+}

--- a/src/Rest/DashboardController.php
+++ b/src/Rest/DashboardController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Amplisio\AIO\Rest;
+
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Repositories\OptionRepository;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+class DashboardController extends WP_REST_Controller
+{
+    public function __construct(private ModuleManager $module_manager, private OptionRepository $options)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'dashboard';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to view Amplisio data.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_items(WP_REST_Request $request): WP_REST_Response
+    {
+        $cards = $this->module_manager->get_dashboard_cards();
+        $theme = $this->options->get_theme_settings();
+
+        return new WP_REST_Response([
+            'cards' => $cards,
+            'theme' => $theme,
+        ]);
+    }
+}

--- a/src/Rest/ModulesController.php
+++ b/src/Rest/ModulesController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Amplisio\AIO\Rest;
+
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Repositories\OptionRepository;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+
+use function __;
+use function current_user_can;
+use function register_rest_route;
+use function rest_authorization_required_code;
+use function sanitize_key;
+use function sprintf;
+
+class ModulesController extends WP_REST_Controller
+{
+    public function __construct(private ModuleManager $modules, private OptionRepository $options)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'modules';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_items'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<module>[a-z0-9_-]+)',
+            [
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'update_item'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_woocommerce')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to manage Amplisio modules.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_items(WP_REST_Request $request): WP_REST_Response
+    {
+        $modules = [];
+
+        foreach ($this->modules->get_modules() as $module) {
+            $settings = $this->modules->get_module_settings($module->get_id());
+
+            $modules[] = [
+                'id'         => $module->get_id(),
+                'name'       => $module->get_name(),
+                'enabled'    => (bool) ($settings['enabled'] ?? false),
+                'settings'   => $settings,
+                'defaults'   => $module->sanitize_settings($module->get_default_settings()),
+                'capability' => $module->get_capability(),
+                'restRoute'  => sprintf('%s/%s', $this->namespace, $module->get_rest_base()),
+            ];
+        }
+
+        return new WP_REST_Response([
+            'modules'  => $modules,
+            'settings' => $this->options->get_modules(),
+        ]);
+    }
+
+    public function update_item(WP_REST_Request $request): WP_REST_Response
+    {
+        $module_id = sanitize_key((string) $request['module']);
+        $module    = $this->modules->get_module($module_id);
+
+        if ( ! $module ) {
+            return new WP_REST_Response([
+                'message' => __('Module not found.', 'amplisio-aio'),
+            ], 404);
+        }
+
+        $params = $request->get_json_params();
+        if ( ! is_array($params) ) {
+            $params = [];
+        }
+
+        $settings = $this->modules->update_module_settings($module_id, $params);
+
+        return new WP_REST_Response([
+            'id'       => $module_id,
+            'name'     => $module->get_name(),
+            'settings' => $settings,
+        ]);
+    }
+}

--- a/src/Rest/SettingsController.php
+++ b/src/Rest/SettingsController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Amplisio\AIO\Rest;
+
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Repositories\OptionRepository;
+use Amplisio\AIO\Services\Helpers\Sanitization;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+
+use function sanitize_key;
+
+class SettingsController extends WP_REST_Controller
+{
+    public function __construct(private OptionRepository $options, private ModuleManager $modules)
+    {
+        $this->namespace = 'amplisio/v1';
+        $this->rest_base = 'settings';
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [$this, 'get_item'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+                [
+                    'methods'             => 'POST',
+                    'callback'            => [$this, 'update_item'],
+                    'permission_callback' => [$this, 'permissions_check'],
+                ],
+            ]
+        );
+    }
+
+    public function permissions_check(): bool|WP_Error
+    {
+        return current_user_can('manage_options')
+            ? true
+            : new WP_Error('rest_forbidden', __('You are not allowed to update Amplisio settings.', 'amplisio-aio'), ['status' => rest_authorization_required_code()]);
+    }
+
+    public function get_item(WP_REST_Request $request): WP_REST_Response
+    {
+        return new WP_REST_Response($this->options->get());
+    }
+
+    public function update_item(WP_REST_Request $request): WP_REST_Response
+    {
+        $body      = $request->get_json_params();
+        $theme_raw = isset($body['theme']) && is_array($body['theme']) ? $body['theme'] : [];
+        $modules   = isset($body['modules']) && is_array($body['modules']) ? $body['modules'] : [];
+
+        $theme = Sanitization::sanitize_theme_settings($theme_raw);
+
+        $this->options->update_theme_settings($theme);
+
+        foreach ($modules as $module_id => $payload) {
+            $key = sanitize_key($module_id);
+            if ('' === $key) {
+                continue;
+            }
+
+            if (is_array($payload)) {
+                $this->modules->update_module_settings($key, $payload);
+            } else {
+                $this->modules->set_module_status($key, (bool) $payload);
+            }
+        }
+
+        return new WP_REST_Response($this->options->get());
+    }
+}

--- a/src/Services/Container.php
+++ b/src/Services/Container.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Amplisio\AIO\Services;
+
+use Closure;
+use RuntimeException;
+
+class Container
+{
+    /**
+     * @var array<string, Closure|object>
+     */
+    private array $bindings = [];
+
+    /**
+     * @var array<string, object>
+     */
+    private array $instances = [];
+
+    public function set(string $id, Closure|object $concrete): void
+    {
+        $this->bindings[$id] = $concrete instanceof Closure
+            ? $concrete
+            : static fn (Container $container): object => $concrete;
+    }
+
+    public function singleton(string $id, Closure|object $concrete): void
+    {
+        $this->bindings[$id] = function (Container $container) use ($id, $concrete) {
+            if ( ! isset($this->instances[$id]) ) {
+                $this->instances[$id] = $concrete instanceof Closure
+                    ? $concrete($container)
+                    : $concrete;
+            }
+
+            return $this->instances[$id];
+        };
+    }
+
+    public function get(string $id): mixed
+    {
+        if ( isset($this->instances[$id]) ) {
+            return $this->instances[$id];
+        }
+
+        if ( ! isset($this->bindings[$id]) ) {
+            throw new RuntimeException(sprintf('Service "%s" is not bound to the container.', $id));
+        }
+
+        $concrete = $this->bindings[$id];
+
+        return $concrete($this);
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->bindings[$id]) || isset($this->instances[$id]);
+    }
+}

--- a/src/Services/Front/ThemeAdapter.php
+++ b/src/Services/Front/ThemeAdapter.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Amplisio\AIO\Services\Front;
+
+use Amplisio\AIO\Repositories\OptionRepository;
+
+use function esc_html;
+use function preg_match;
+use function preg_replace;
+use function sanitize_hex_color;
+use function sprintf;
+use function str_starts_with;
+use function trim;
+use function wp_strip_all_tags;
+
+class ThemeAdapter
+{
+    private const DEFAULT_FONT_FAMILY = '"Inter", sans-serif';
+    private const DEFAULT_PRIMARY_COLOR = '#2563eb';
+    private const DEFAULT_ACCENT_COLOR  = '#ec4899';
+    private const DEFAULT_RADIUS        = '12px';
+
+    private const FONT_VARIABLES = [
+        '--wp--preset--font-family--body',
+        '--wp--custom--font-family--body',
+        '--global--font-family-base',
+    ];
+
+    private const PRIMARY_COLOR_VARIABLES = [
+        '--wp--preset--color--primary',
+        '--wp--custom--color--primary',
+        '--global--color-primary',
+    ];
+
+    private const ACCENT_COLOR_VARIABLES = [
+        '--wp--preset--color--secondary',
+        '--wp--preset--color--accent',
+        '--global--color-secondary',
+    ];
+
+    private const RADIUS_VARIABLES = [
+        '--wp--preset--border-radius--outer',
+        '--wp--custom--border-radius',
+        '--global--border-radius',
+    ];
+
+    private bool $rendered = false;
+
+    public function __construct(private OptionRepository $options)
+    {
+    }
+
+    public function get_css_variables(): array
+    {
+        $settings = $this->options->get_theme_settings();
+
+        return [
+            '--amplisio-font-family' => $this->resolve_font_family($settings['fontFamily'] ?? ''),
+            '--amplisio-primary'     => $this->resolve_color($settings['primaryColor'] ?? '', self::PRIMARY_COLOR_VARIABLES, self::DEFAULT_PRIMARY_COLOR),
+            '--amplisio-accent'      => $this->resolve_color($settings['accentColor'] ?? '', self::ACCENT_COLOR_VARIABLES, self::DEFAULT_ACCENT_COLOR),
+            '--amplisio-radius'      => $this->resolve_radius($settings['radius'] ?? ''),
+        ];
+    }
+
+    public function get_fallbacks(): array
+    {
+        return [
+            'fontFamily'   => self::DEFAULT_FONT_FAMILY,
+            'primaryColor' => self::DEFAULT_PRIMARY_COLOR,
+            'accentColor'  => self::DEFAULT_ACCENT_COLOR,
+            'radius'       => self::DEFAULT_RADIUS,
+        ];
+    }
+
+    public function build_style_block(string $selector = ':root'): string
+    {
+        $selector = trim($selector) ?: ':root';
+
+        $variables = $this->get_css_variables();
+        $declarations = [];
+
+        foreach ($variables as $name => $value) {
+            if ('' === $name || '' === $value) {
+                continue;
+            }
+
+            $declarations[] = sprintf('%s: %s;', $name, $value);
+        }
+
+        if (empty($declarations)) {
+            return '';
+        }
+
+        return sprintf(
+            '<style id="amplisio-aio-theme-vars">%s{%s}</style>',
+            esc_html($selector),
+            esc_html(implode(' ', $declarations))
+        );
+    }
+
+    public function output_root_variables(): void
+    {
+        if ($this->rendered) {
+            return;
+        }
+
+        $block = $this->build_style_block(':root');
+        if ('' === $block) {
+            return;
+        }
+
+        echo $block; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        $this->rendered = true;
+    }
+
+    private function resolve_font_family(string $override): string
+    {
+        $override = $this->sanitize_font_override($override);
+
+        if ('' !== $override) {
+            return $override;
+        }
+
+        return $this->build_var_chain(self::FONT_VARIABLES, self::DEFAULT_FONT_FAMILY);
+    }
+
+    private function resolve_color(string $override, array $variables, string $fallback): string
+    {
+        $override = $this->sanitize_color_override($override);
+
+        if ('' !== $override) {
+            return $override;
+        }
+
+        return $this->build_var_chain($variables, $fallback);
+    }
+
+    private function resolve_radius(string $override): string
+    {
+        $override = $this->sanitize_radius_override($override);
+
+        if ('' !== $override) {
+            return $override;
+        }
+
+        return $this->build_var_chain(self::RADIUS_VARIABLES, self::DEFAULT_RADIUS);
+    }
+
+    private function build_var_chain(array $variables, string $fallback): string
+    {
+        $chain = $fallback;
+
+        foreach (array_reverse($variables) as $variable) {
+            $variable = trim($variable);
+
+            if ('' === $variable) {
+                continue;
+            }
+
+            $chain = sprintf('var(%s, %s)', $variable, $chain);
+        }
+
+        return $chain;
+    }
+
+    private function sanitize_font_override(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        $value = wp_strip_all_tags($value);
+        $value = preg_replace("/[^\\w\\s,\"'-]/u", '', $value);
+
+        return trim($value);
+    }
+
+    private function sanitize_color_override(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        $hex = sanitize_hex_color($value);
+
+        return $hex ?: '';
+    }
+
+    private function sanitize_radius_override(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        if ('0' === $value) {
+            return '0';
+        }
+
+        if (preg_match('/^\d+(?:\.\d+)?(px|rem|em|%)$/', $value)) {
+            return $value;
+        }
+
+        return '';
+    }
+}

--- a/src/Services/Helpers/Sanitization.php
+++ b/src/Services/Helpers/Sanitization.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Amplisio\AIO\Services\Helpers;
+
+use function preg_match;
+use function preg_replace;
+use function sanitize_hex_color;
+use function str_starts_with;
+use function trim;
+use function wp_strip_all_tags;
+
+class Sanitization
+{
+    public static function sanitize_theme_settings(array $settings): array
+    {
+        return [
+            'fontFamily'   => self::sanitize_font_family($settings['fontFamily'] ?? ''),
+            'primaryColor' => self::sanitize_color($settings['primaryColor'] ?? ''),
+            'accentColor'  => self::sanitize_color($settings['accentColor'] ?? ''),
+            'radius'       => self::sanitize_radius($settings['radius'] ?? ''),
+        ];
+    }
+
+    private static function sanitize_font_family(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        $value = wp_strip_all_tags($value);
+        $value = preg_replace("/[^\\w\\s,\"'-]/u", '', $value);
+
+        return trim($value);
+    }
+
+    private static function sanitize_color(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        $hex = sanitize_hex_color($value);
+
+        return $hex ?: '';
+    }
+
+    private static function sanitize_radius(string $value): string
+    {
+        $value = trim($value);
+
+        if ('' === $value) {
+            return '';
+        }
+
+        if (str_starts_with($value, 'var(') && preg_match('/^var\(--[a-z0-9_-]+(?:,\s*[^\)]+)?\)$/i', $value)) {
+            return $value;
+        }
+
+        if ('0' === $value) {
+            return '0';
+        }
+
+        if (preg_match('/^\d+(?:\.\d+)?(px|rem|em|%)$/', $value)) {
+            return $value;
+        }
+
+        return '';
+    }
+}

--- a/src/Services/Providers/CoreServiceProvider.php
+++ b/src/Services/Providers/CoreServiceProvider.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Amplisio\AIO\Services\Providers;
+
+use Amplisio\AIO\CLI\Commands\ModuleToggleCommand;
+use Amplisio\AIO\CLI\Commands\StatusCommand;
+use Amplisio\AIO\Modules\AbandonedCart\AbandonedCartModule;
+use Amplisio\AIO\Modules\Analytics\AnalyticsModule;
+use Amplisio\AIO\Modules\BackInStock\BackInStockModule;
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Modules\RecoveredCarts\RecoveredCartsModule;
+use Amplisio\AIO\Repositories\OptionRepository;
+use Amplisio\AIO\Rest\DashboardController;
+use Amplisio\AIO\Rest\ModulesController;
+use Amplisio\AIO\Rest\SettingsController;
+use Amplisio\AIO\Services\Container;
+use Amplisio\AIO\Services\Front\ThemeAdapter;
+use Amplisio\AIO\Services\Scheduler\ActionSchedulerService;
+
+use function sprintf;
+
+class CoreServiceProvider
+{
+    public function __construct(private Container $container, private string $plugin_file)
+    {
+    }
+
+    public function register(): void
+    {
+        $this->container->singleton(ModuleManager::class, function (Container $container): ModuleManager {
+            return new ModuleManager(
+                $container->get(OptionRepository::class),
+                $container
+            );
+        });
+
+        $this->container->singleton(ThemeAdapter::class, function (Container $container): ThemeAdapter {
+            return new ThemeAdapter($container->get(OptionRepository::class));
+        });
+
+        $this->container->singleton(ActionSchedulerService::class, function (Container $container): ActionSchedulerService {
+            return new ActionSchedulerService($container->get(ModuleManager::class));
+        });
+    }
+
+    public function boot(): void
+    {
+        $module_manager = $this->container->get(ModuleManager::class);
+
+        $module_manager->register_module(new AnalyticsModule());
+        $module_manager->register_module(new AbandonedCartModule());
+        $module_manager->register_module(new RecoveredCartsModule());
+        $module_manager->register_module(new BackInStockModule());
+
+        $module_manager->boot_enabled_modules();
+
+        $this->register_admin_assets();
+        $this->register_rest_controllers();
+        $this->register_cli_commands();
+        $this->register_scheduler();
+        $this->register_front_theme();
+    }
+
+    private function register_admin_assets(): void
+    {
+        add_action('admin_menu', [$this, 'register_dashboard_page']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
+    }
+
+    public function register_dashboard_page(): void
+    {
+        add_menu_page(
+            __('Amplisio', 'amplisio-aio'),
+            __('Amplisio', 'amplisio-aio'),
+            'manage_woocommerce',
+            'amplisio-dashboard',
+            [$this, 'render_dashboard_page'],
+            'dashicons-chart-line'
+        );
+    }
+
+    public function render_dashboard_page(): void
+    {
+        echo '<div class="wrap amplisio-dashboard"><div id="amplisio-aio-dashboard" class="amplisio-dashboard__root" aria-live="polite"></div></div>';
+    }
+
+    public function enqueue_admin_assets(string $hook): void
+    {
+        if ( 'toplevel_page_amplisio-dashboard' !== $hook ) {
+            return;
+        }
+
+        $asset_url = plugins_url('build/admin-dashboard.js', $this->plugin_file);
+        $css_url   = plugins_url('build/admin-dashboard.css', $this->plugin_file);
+
+        wp_enqueue_script(
+            'amplisio-aio-admin',
+            $asset_url,
+            [],
+            AMPLISIO_AIO_VERSION,
+            true
+        );
+
+        $module_manager = $this->container->get(ModuleManager::class);
+        $options        = $this->container->get(OptionRepository::class);
+        $theme_adapter  = $this->container->get(ThemeAdapter::class);
+
+        wp_localize_script('amplisio-aio-admin', 'amplisioAioData', [
+            'root'     => esc_url_raw(rest_url('amplisio/v1')),
+            'nonce'    => wp_create_nonce('wp_rest'),
+            'settings' => $options->get(),
+            'themeFallbacks' => $theme_adapter->get_fallbacks(),
+            'themeCssVariables' => $theme_adapter->get_css_variables(),
+            'modules'  => array_map(
+                static function ($module) use ($module_manager): array {
+                    $settings = $module_manager->get_module_settings($module->get_id());
+
+                    return [
+                        'id'         => $module->get_id(),
+                        'name'       => $module->get_name(),
+                        'enabled'    => (bool) ($settings['enabled'] ?? false),
+                        'capability' => $module->get_capability(),
+                        'restRoute'  => sprintf('amplisio/v1/%s', $module->get_rest_base()),
+                        'settings'   => $settings,
+                    ];
+                },
+                $module_manager->get_modules()
+            ),
+        ]);
+
+        wp_enqueue_style('amplisio-aio-admin', $css_url, [], AMPLISIO_AIO_VERSION);
+    }
+
+    private function register_rest_controllers(): void
+    {
+        $dashboard_controller = new DashboardController(
+            $this->container->get(ModuleManager::class),
+            $this->container->get(OptionRepository::class)
+        );
+
+        $settings_controller = new SettingsController(
+            $this->container->get(OptionRepository::class),
+            $this->container->get(ModuleManager::class)
+        );
+
+        $modules_controller = new ModulesController(
+            $this->container->get(ModuleManager::class),
+            $this->container->get(OptionRepository::class)
+        );
+
+        add_action('rest_api_init', static function () use ($dashboard_controller, $settings_controller, $modules_controller): void {
+            $dashboard_controller->register_routes();
+            $settings_controller->register_routes();
+            $modules_controller->register_routes();
+        });
+    }
+
+    private function register_cli_commands(): void
+    {
+        if ( defined('WP_CLI') && WP_CLI ) {
+            \WP_CLI::add_command('amplisio status', new StatusCommand(
+                $this->container->get(ModuleManager::class),
+                $this->container->get(OptionRepository::class)
+            ));
+
+            \WP_CLI::add_command('amplisio module', new ModuleToggleCommand(
+                $this->container->get(ModuleManager::class)
+            ));
+        }
+    }
+
+    private function register_scheduler(): void
+    {
+        $scheduler = $this->container->get(ActionSchedulerService::class);
+        $scheduler->register();
+    }
+
+    private function register_front_theme(): void
+    {
+        add_action('wp_head', function (): void {
+            $this->container->get(ThemeAdapter::class)->output_root_variables();
+        }, 20);
+    }
+}

--- a/src/Services/Scheduler/ActionSchedulerService.php
+++ b/src/Services/Scheduler/ActionSchedulerService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Amplisio\AIO\Services\Scheduler;
+
+use Amplisio\AIO\Modules\ModuleManager;
+
+class ActionSchedulerService
+{
+    public const HOOK = 'amplisio_aio_scheduled_run';
+
+    public function __construct(private ModuleManager $module_manager)
+    {
+    }
+
+    public function register(): void
+    {
+        add_action('init', [$this, 'schedule']);
+        add_action(self::HOOK, [$this, 'handle']);
+    }
+
+    public function schedule(): void
+    {
+        if ( ! function_exists('as_has_scheduled_action') ) {
+            return;
+        }
+
+        if ( ! as_has_scheduled_action(self::HOOK) ) {
+            as_schedule_recurring_action(time() + HOUR_IN_SECONDS, DAY_IN_SECONDS, self::HOOK);
+        }
+    }
+
+    public function handle(): void
+    {
+        $this->module_manager->run_scheduled_events();
+    }
+}

--- a/tests/CLI/AmplisioCliTest.php
+++ b/tests/CLI/AmplisioCliTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Plugin;
+use Amplisio\AIO\Repositories\OptionRepository;
+
+if ( ! class_exists('WP_CLI') ) {
+    class WP_CLI
+    {
+        public static array $commands = [];
+        public static array $messages = [];
+
+        public static function add_command(string $name, $callable): void
+        {
+            self::$commands[$name] = $callable;
+        }
+
+        public static function log(string $message): void
+        {
+            self::$messages[] = $message;
+        }
+
+        public static function success(string $message): void
+        {
+            self::$messages[] = $message;
+        }
+
+        public static function error(string $message): void
+        {
+            throw new RuntimeException($message);
+        }
+
+        public static function reset(): void
+        {
+            self::$messages = [];
+        }
+    }
+}
+
+if ( ! defined('WP_CLI') ) {
+    define('WP_CLI', true);
+}
+
+class AmplisioCliTest extends WP_UnitTestCase
+{
+    private Plugin $plugin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        WP_CLI::$commands = [];
+        WP_CLI::reset();
+
+        delete_option(OptionRepository::OPTION_KEY);
+        delete_option('amplisio_aio_abandoned_sequences');
+
+        $this->plugin = new Plugin(AMPLISIO_AIO_FILE);
+        $this->plugin->init();
+    }
+
+    public function test_status_command_outputs_registered_modules(): void
+    {
+        $this->assertArrayHasKey('amplisio status', WP_CLI::$commands);
+
+        WP_CLI::reset();
+        call_user_func(WP_CLI::$commands['amplisio status']);
+
+        $this->assertNotEmpty(WP_CLI::$messages);
+        $this->assertStringContainsString('Amplisio AIO v', WP_CLI::$messages[0]);
+
+        $this->assertTrue($this->arrayContainsSubstring(WP_CLI::$messages, 'Intelligence'));
+    }
+
+    public function test_module_command_toggles_module_status(): void
+    {
+        $this->assertArrayHasKey('amplisio module', WP_CLI::$commands);
+
+        /** @var ModuleManager $manager */
+        $manager = $this->plugin->container()->get(ModuleManager::class);
+        $settings = $manager->get_module_settings('abandoned_cart');
+        $this->assertFalse($settings['enabled']);
+
+        WP_CLI::reset();
+        call_user_func(WP_CLI::$commands['amplisio module'], 'enable', 'abandoned_cart');
+
+        $settings = $manager->get_module_settings('abandoned_cart');
+        $this->assertTrue($settings['enabled']);
+
+        $this->assertTrue($this->arrayContainsSubstring(WP_CLI::$messages, 'Enabled Abandoned cart recovery'));
+    }
+
+    private function arrayContainsSubstring(array $messages, string $needle): bool
+    {
+        foreach ($messages as $message) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Modules/AbandonedCart/AbandonedCartSequenceRepositoryTest.php
+++ b/tests/Modules/AbandonedCart/AbandonedCartSequenceRepositoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Amplisio\AIO\Modules\AbandonedCart\AbandonedCartSequenceRepository;
+
+class AbandonedCartSequenceRepositoryTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        delete_option('amplisio_aio_abandoned_sequences');
+    }
+
+    public function test_get_settings_returns_defaults_when_empty(): void
+    {
+        $repository = new AbandonedCartSequenceRepository();
+
+        $settings = $repository->get_settings();
+
+        $this->assertSame(60, $settings['abandonAfterMinutes']);
+        $this->assertSame(14, $settings['expireAfterDays']);
+        $this->assertCount(2, $settings['sequences']);
+    }
+
+    public function test_update_settings_sanitizes_sequences(): void
+    {
+        $repository = new AbandonedCartSequenceRepository();
+
+        $repository->update_settings([
+            'abandonAfterMinutes' => 2,
+            'expireAfterDays'     => 0,
+            'sequences'           => [
+                [
+                    'id'             => '  Reminder One ',
+                    'name'           => '<strong>Reminder</strong> #1',
+                    'delay'          => 1,
+                    'subject'        => '<span>Subject</span>',
+                    'body'           => '<script>alert(1)</script><p><strong>Hi</strong></p>',
+                    'autoCoupon'     => '1',
+                    'couponType'     => 'bogus',
+                    'couponAmount'   => '15.5',
+                    'couponExpiryDays' => 0,
+                ],
+                [
+                    'id'   => '',
+                    'name' => 'Missing id',
+                ],
+            ],
+        ]);
+
+        $settings = $repository->get_settings();
+
+        $this->assertSame(5, $settings['abandonAfterMinutes']);
+        $this->assertSame(1, $settings['expireAfterDays']);
+        $this->assertCount(1, $settings['sequences']);
+
+        $sequence = $settings['sequences'][0];
+
+        $this->assertSame('reminder-one', $sequence['id']);
+        $this->assertSame('Reminder #1', $sequence['name']);
+        $this->assertSame(5, $sequence['delay']);
+        $this->assertSame('Subject', $sequence['subject']);
+        $this->assertSame('<p><strong>Hi</strong></p>', $sequence['body']);
+        $this->assertTrue($sequence['autoCoupon']);
+        $this->assertSame('percent', $sequence['couponType']);
+        $this->assertSame(15.5, $sequence['couponAmount']);
+        $this->assertSame(1, $sequence['couponExpiryDays']);
+    }
+}

--- a/tests/Modules/AbandonedCart/AbandonedCartServiceTest.php
+++ b/tests/Modules/AbandonedCart/AbandonedCartServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Amplisio\AIO\Modules\AbandonedCart\AbandonedCartService;
+
+class AbandonedCartServiceTest extends WP_UnitTestCase
+{
+    private AbandonedCartService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        global $wpdb;
+        $this->service = new AbandonedCartService($wpdb);
+        $this->service->maybe_create_table();
+    }
+
+    public function test_status_transitions(): void
+    {
+        $cart = $this->createCart();
+
+        global $wpdb;
+        $wpdb->update(
+            $this->service->get_table_name(),
+            ['updated_at' => gmdate('Y-m-d H:i:s', strtotime('-2 hours'))],
+            ['id' => $cart['id']]
+        );
+
+        $this->service->mark_carts_abandoned(60);
+
+        $cart = $this->service->get_cart_by_key($cart['cart_key']);
+        $this->assertNotNull($cart);
+        $this->assertSame('abandoned', $cart['status']);
+        $this->assertNotEmpty($cart['abandoned_at']);
+
+        $this->service->mark_recovered((int) $cart['id'], 42, 120.0, 'customer@example.com', 'Jane');
+        $cart = $this->service->get_cart_by_key($cart['cart_key']);
+        $this->assertSame('recovered', $cart['status']);
+        $this->assertSame(42, (int) $cart['recovered_order_id']);
+
+        $wpdb->update(
+            $this->service->get_table_name(),
+            [
+                'status'       => 'abandoned',
+                'abandoned_at' => gmdate('Y-m-d H:i:s', strtotime('-20 days')),
+            ],
+            ['id' => $cart['id']]
+        );
+
+        $this->service->expire_abandoned_carts(14);
+
+        $cart = $this->service->get_cart_by_key($cart['cart_key']);
+        $this->assertSame('expired', $cart['status']);
+    }
+
+    public function test_coupon_issue_records_code(): void
+    {
+        $cart = $this->createCart();
+
+        add_filter(
+            'amplisio_aio_generate_coupon',
+            static fn ($coupon, $cart_id, $email, $config) => [
+                'code'       => 'TESTCOUPON',
+                'expires_at' => gmdate('Y-m-d H:i:s', strtotime('+2 days')),
+            ],
+            10,
+            4
+        );
+
+        $result = $this->service->issue_coupon_for_cart($cart['id'], 'customer@example.com', []);
+        remove_all_filters('amplisio_aio_generate_coupon');
+
+        $this->assertSame('TESTCOUPON', $result['code']);
+
+        $stored = $this->service->get_cart($cart['id']);
+        $this->assertSame('TESTCOUPON', $stored['coupon_code']);
+    }
+
+    private function createCart(): array
+    {
+        $cart_key = 'cart-' . wp_generate_uuid4();
+
+        $this->service->record_cart($cart_key, [
+            'email'      => 'customer@example.com',
+            'consent'    => true,
+            'first_name' => 'Jane',
+            'items'      => [
+                [
+                    'product_id' => 1,
+                    'quantity'   => 1,
+                    'name'       => 'Sample product',
+                ],
+            ],
+            'subtotal'   => 99.0,
+        ]);
+
+        $cart = $this->service->get_cart_by_key($cart_key);
+        $this->assertNotNull($cart);
+
+        return $cart;
+    }
+}

--- a/tests/Modules/ModuleManagerTest.php
+++ b/tests/Modules/ModuleManagerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use Amplisio\AIO\Modules\AbstractModule;
+use Amplisio\AIO\Modules\ModuleManager;
+use Amplisio\AIO\Repositories\OptionRepository;
+use Amplisio\AIO\Services\Container;
+
+class ModuleManagerTest extends WP_UnitTestCase
+{
+    private ModuleManager $manager;
+    private OptionRepository $options;
+    private Container $container;
+    private ModuleManagerTestModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        delete_option(OptionRepository::OPTION_KEY);
+
+        $this->options   = new OptionRepository();
+        $this->container = new Container();
+        $this->container->singleton(OptionRepository::class, fn (): OptionRepository => $this->options);
+
+        $this->manager = new ModuleManager($this->options, $this->container);
+        $this->module  = new ModuleManagerTestModule();
+    }
+
+    public function test_register_module_persists_default_settings(): void
+    {
+        $this->manager->register_module($this->module);
+
+        $this->assertTrue($this->module->registered);
+
+        $modules = $this->options->get_modules();
+        $this->assertArrayHasKey('test-module', $modules);
+        $this->assertSame([
+            'enabled'   => false,
+            'threshold' => 10,
+        ], $modules['test-module']);
+    }
+
+    public function test_boot_enabled_modules_only_boots_enabled_entries(): void
+    {
+        $this->manager->register_module($this->module);
+        $this->manager->boot_enabled_modules();
+
+        $this->assertFalse($this->module->booted);
+
+        $this->manager->set_module_status('test-module', true);
+        $this->manager->boot_enabled_modules();
+
+        $this->assertTrue($this->module->booted);
+    }
+
+    public function test_update_module_settings_merges_and_sanitizes(): void
+    {
+        $this->manager->register_module($this->module);
+
+        $settings = $this->manager->update_module_settings('test-module', [
+            'enabled'   => '1',
+            'threshold' => -5,
+        ]);
+
+        $this->assertSame([
+            'enabled'   => true,
+            'threshold' => 0,
+        ], $settings);
+
+        $stored = $this->manager->get_module_settings('test-module');
+        $this->assertSame($settings, $stored);
+    }
+}
+
+class ModuleManagerTestModule extends AbstractModule
+{
+    public bool $registered = false;
+    public bool $booted = false;
+
+    public function get_id(): string
+    {
+        return 'test-module';
+    }
+
+    public function get_name(): string
+    {
+        return 'Test Module';
+    }
+
+    public function register(Container $container): void
+    {
+        $this->registered = true;
+    }
+
+    public function boot(Container $container): void
+    {
+        $this->booted = true;
+    }
+
+    public function get_default_settings(): array
+    {
+        return [
+            'enabled'   => false,
+            'threshold' => 10,
+        ];
+    }
+
+    public function sanitize_settings(array $settings): array
+    {
+        $sanitized = parent::sanitize_settings($settings);
+        $sanitized['threshold'] = max(0, (int) $sanitized['threshold']);
+
+        return $sanitized;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+$_tests_dir = getenv('WP_TESTS_DIR');
+
+if ( ! $_tests_dir ) {
+    $_tests_dir = rtrim(sys_get_temp_dir(), '/\') . '/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+require $_tests_dir . '/includes/bootstrap.php';
+
+require_once dirname(__DIR__) . '/amplisio-aio.php';


### PR DESCRIPTION
## Summary
- load the plugin during the PHPUnit bootstrap to support end-to-end assertions
- cover abandoned cart sequence sanitization and module manager state handling with dedicated unit tests
- add a WP-CLI smoke test to verify status listings and module toggling commands

## Testing
- php -l tests/Modules/AbandonedCart/AbandonedCartSequenceRepositoryTest.php
- php -l tests/Modules/ModuleManagerTest.php
- php -l tests/CLI/AmplisioCliTest.php
- phpunit *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1630d8c483278b86615836cd3c9d